### PR TITLE
fix: Enforce validation on notation signature blob number

### DIFF
--- a/pkg/referrerstore/oras/mocks/oras_storage.go
+++ b/pkg/referrerstore/oras/mocks/oras_storage.go
@@ -28,9 +28,14 @@ import (
 type TestStorage struct {
 	content.Storage
 	ExistsMap map[digest.Digest]io.Reader
+	ExistsErr error
+	FetchErr  error
 }
 
 func (s TestStorage) Exists(_ context.Context, target oci.Descriptor) (bool, error) {
+	if s.ExistsErr != nil {
+		return false, s.ExistsErr
+	}
 	if _, ok := s.ExistsMap[target.Digest]; ok {
 		return true, nil
 	}
@@ -43,6 +48,9 @@ func (s TestStorage) Push(_ context.Context, expected oci.Descriptor, content io
 }
 
 func (s TestStorage) Fetch(_ context.Context, target oci.Descriptor) (io.ReadCloser, error) {
+	if s.FetchErr != nil {
+		return nil, s.FetchErr
+	}
 	if reader, ok := s.ExistsMap[target.Digest]; ok {
 		return io.NopCloser(reader), nil
 	}

--- a/pkg/verifier/notation/notation.go
+++ b/pkg/verifier/notation/notation.go
@@ -150,29 +150,28 @@ func (v *notationPluginVerifier) Verify(ctx context.Context,
 		return verifier.VerifierResult{IsSuccess: false}, re.ErrorCodeGetReferenceManifestFailure.NewError(re.ReferrerStore, store.Name(), re.EmptyLink, err, fmt.Sprintf("failed to resolve reference manifest: %+v", referenceDescriptor), re.HideStackTrace)
 	}
 
-	if len(referenceManifest.Blobs) == 0 {
-		return verifier.VerifierResult{IsSuccess: false}, re.ErrorCodeSignatureNotFound.NewError(re.Verifier, v.name, re.EmptyLink, nil, fmt.Sprintf("no signature content found for referrer: %s@%s", subjectReference.Path, referenceDescriptor.Digest.String()), re.HideStackTrace)
+	if len(referenceManifest.Blobs) != 1 {
+		return verifier.VerifierResult{IsSuccess: false}, re.ErrorCodeVerifyPluginFailure.WithDetail(fmt.Sprintf("Notation signature manifest requires exactly one signature envelope blob, got %d", len(referenceManifest.Blobs))).WithRemediation(fmt.Sprintf("Please inspect the artifact [%s@%s] is correctly signed by Notation signer", subjectReference.Path, referenceDescriptor.Digest.String()))
 	}
 
-	for _, blobDesc := range referenceManifest.Blobs {
-		refBlob, err := store.GetBlobContent(ctx, subjectReference, blobDesc.Digest)
-		if err != nil {
-			return verifier.VerifierResult{IsSuccess: false}, re.ErrorCodeGetBlobContentFailure.NewError(re.ReferrerStore, store.Name(), re.EmptyLink, err, fmt.Sprintf("failed to get blob content of digest: %s", blobDesc.Digest), re.HideStackTrace)
-		}
-
-		// TODO: notation verify API only accepts digested reference now.
-		// Pass in tagged reference instead once notation-go supports it.
-		subjectRef := fmt.Sprintf("%s@%s", subjectReference.Path, subjectReference.Digest.String())
-		outcome, err := v.verifySignature(ctx, subjectRef, blobDesc.MediaType, subjectDesc.Descriptor, refBlob)
-		if err != nil {
-			return verifier.VerifierResult{IsSuccess: false, Extensions: extensions}, re.ErrorCodeVerifyPluginFailure.NewError(re.Verifier, v.name, re.NotationTsgLink, err, "failed to verify signature of digest", re.HideStackTrace)
-		}
-
-		// Note: notation verifier already validates certificate chain is not empty.
-		cert := outcome.EnvelopeContent.SignerInfo.CertificateChain[0]
-		extensions["Issuer"] = cert.Issuer.String()
-		extensions["SN"] = cert.Subject.String()
+	blobDesc := referenceManifest.Blobs[0]
+	refBlob, err := store.GetBlobContent(ctx, subjectReference, blobDesc.Digest)
+	if err != nil {
+		return verifier.VerifierResult{IsSuccess: false}, re.ErrorCodeGetBlobContentFailure.NewError(re.ReferrerStore, store.Name(), re.EmptyLink, err, fmt.Sprintf("failed to get blob content of digest: %s", blobDesc.Digest), re.HideStackTrace)
 	}
+
+	// TODO: notation verify API only accepts digested reference now.
+	// Pass in tagged reference instead once notation-go supports it.
+	subjectRef := fmt.Sprintf("%s@%s", subjectReference.Path, subjectReference.Digest.String())
+	outcome, err := v.verifySignature(ctx, subjectRef, blobDesc.MediaType, subjectDesc.Descriptor, refBlob)
+	if err != nil {
+		return verifier.VerifierResult{IsSuccess: false, Extensions: extensions}, re.ErrorCodeVerifyPluginFailure.NewError(re.Verifier, v.name, re.NotationTsgLink, err, "failed to verify signature of digest", re.HideStackTrace)
+	}
+
+	// Note: notation verifier already validates certificate chain is not empty.
+	cert := outcome.EnvelopeContent.SignerInfo.CertificateChain[0]
+	extensions["Issuer"] = cert.Issuer.String()
+	extensions["SN"] = cert.Subject.String()
 
 	return verifier.VerifierResult{
 		Name:         v.name,

--- a/pkg/verifier/notation/notation_test.go
+++ b/pkg/verifier/notation/notation_test.go
@@ -368,6 +368,26 @@ func TestVerify(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name:    "multiple signature blobs",
+			ref:     validRef2,
+			refBlob: testRefBlob2,
+			manifest: ocispecs.ReferenceManifest{
+				Blobs: []ocispec.Descriptor{validBlobDesc, validBlobDesc2},
+			},
+			expect:    failedResult,
+			expectErr: true,
+		},
+		{
+			name:    "get blob content failed",
+			ref:     validRef,
+			refBlob: nil,
+			manifest: ocispecs.ReferenceManifest{
+				Blobs: []ocispec.Descriptor{validBlobDesc},
+			},
+			expect:    failedResult,
+			expectErr: true,
+		},
+		{
 			name:    "verified successfully",
 			ref:     validRef,
 			refBlob: testRefBlob,


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
1. A quick fix to enforce validation on the Notation signature blob number. There should be exactly 1 blob in the manifest.Blobs which is also validated in Notation-go: https://github.com/notaryproject/notation-go/blob/8e2131d192fdb71c5268f81b4b9b93069559d3b5/registry/repository.go#L198
2. Remove critical cache failure in oras `GetReferenceManifest`

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
