### PR TITLE
Add tests for KeyManagementProvider refresh logic and certificate ver…

### DIFF
--- a/scripts/azure-ci-test.sh
+++ b/scripts/azure-ci-test.sh
@@ -36,6 +36,8 @@ export AZURE_SP_OBJECT_ID=$6
 export NOTATION_PEM_NAME="notation"
 export NOTATION_CHAIN_PEM_NAME="notationchain"
 export KEYVAULT_KEY_NAME="test-key"
+export IDENTITY_CLIENT_ID=$(az identity show --name ${USER_ASSIGNED_IDENTITY_NAME} --resource-group ${GROUP_NAME} --query 'clientId' -o tsv)
+export VAULT_URI=$(az keyvault show --name ${KEYVAULT_NAME} --resource-group ${GROUP_NAME} --query "properties.vaultUri" -otsv)
 
 TAG="test${SUFFIX}"
 REGISTRY="${ACR_NAME}.azurecr.io"
@@ -56,8 +58,6 @@ deploy_gatekeeper() {
 
 deploy_ratify() {
   echo "deploying ratify"
-  local IDENTITY_CLIENT_ID=$(az identity show --name ${USER_ASSIGNED_IDENTITY_NAME} --resource-group ${GROUP_NAME} --query 'clientId' -o tsv)
-  local VAULT_URI=$(az keyvault show --name ${KEYVAULT_NAME} --resource-group ${GROUP_NAME} --query "properties.vaultUri" -otsv)
 
   helm install ratify \
     ./charts/ratify --atomic \
@@ -142,7 +142,7 @@ trap cleanup EXIT
 main() {
   ./scripts/create-azure-resources.sh
   create_key_akv
-  
+
   local ACR_USER_NAME="00000000-0000-0000-0000-000000000000"
   local ACR_PASSWORD=$(az acr login --name ${ACR_NAME} --expose-token --output tsv --query accessToken)
   make e2e-azure-setup TEST_REGISTRY=$REGISTRY TEST_REGISTRY_USERNAME=${ACR_USER_NAME} TEST_REGISTRY_PASSWORD=${ACR_PASSWORD} KEYVAULT_KEY_NAME=${KEYVAULT_KEY_NAME} KEYVAULT_NAME=${KEYVAULT_NAME}


### PR DESCRIPTION
# Description

## What this PR does / why we need it: 

Adds end to end testing coverage for the kmp refresh feature #1625 

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes # 

## Type of change

- [x] E2E tests

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Validate the refresher is enabled by counting reconcile events in the Ratify logs
- [x] Validate certificate versions update with no version specified
- [x] Validate certificate versions do not update when a version is specified


# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`