### PR TITLE
fix: Revert "chore: update default constraint template"

### DIFF
--- a/library/default/template.yaml
+++ b/library/default/template.yaml
@@ -40,5 +40,5 @@ spec:
         general_violation[{"result": result}] {
           subject_validation := remote_data.responses[_]
           subject_validation[1].isSuccess == false
-          result := sprintf("Time=%s, failed to verify the artifact: %s, trace-id: %s", [subject_validation[1].timestamp, subject_validation[0], subject_validation[1].traceID])
+          result := sprintf("Subject failed verification: %s", [subject_validation[0]])
         }


### PR DESCRIPTION
Reverts ratify-project/ratify#1732

It's currently blocking the quick-test job as Ratify v1.2 does not support exporting traceID and Time