### PR TITLE
fix: remove nonexistent KMP from verifier sample

### DIFF
--- a/config/samples/clustered/verifier/config_v1beta1_verifier_notation_kmprovider.yaml
+++ b/config/samples/clustered/verifier/config_v1beta1_verifier_notation_kmprovider.yaml
@@ -9,10 +9,8 @@ spec:
     verificationCertStores:
       certs:
         - kmprovider-akv
-        - kmprovider-akv1
       certs1:
-        - kmprovider-akv2
-        - kmprovider-akv3
+        - kmprovider-akv1
     trustPolicyDoc:
       version: "1.0"
       trustPolicies:

--- a/config/samples/namespaced/verifier/config_v1beta1_verifier_notation_kmprovider.yaml
+++ b/config/samples/namespaced/verifier/config_v1beta1_verifier_notation_kmprovider.yaml
@@ -9,10 +9,8 @@ spec:
     verificationCertStores:
       certs:
         - kmprovider-akv
-        - kmprovider-akv1
       certs1:
-        - kmprovider-akv2
-        - kmprovider-akv3
+        - kmprovider-akv1
     trustPolicyDoc:
       version: "1.0"
       trustPolicies:

--- a/library/multi-tenancy-validation/template.yaml
+++ b/library/multi-tenancy-validation/template.yaml
@@ -44,5 +44,5 @@ spec:
         general_violation[{"result": result}] {
           subject_validation := remote_data.responses[_]
           subject_validation[1].isSuccess == false
-          result := sprintf("Failed to verify the artifact: %s", [subject_validation[0]])
+          result := sprintf("Time=%s, failed to verify the artifact: %s, trace-id: %s", [subject_validation[1].timestamp, subject_validation[0], subject_validation[1].traceID])
         }


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Recently we made a change to how verifier references a KMP: https://github.com/ratify-project/ratify/pull/1710
Previously we would just ignore a nonexistent KMP in verifier, after this PR, we would return the error indicating the misconfiguration in verifier config.

This PR removes unused KMP from the sample verifier which is referenced in azure-test. And update the constraint template so that it will report the traceID to help us debug in dumped log.

It already passed on my forked repo: 
![image](https://github.com/user-attachments/assets/5380f184-c8b1-47dd-abca-6293c0c61b42)


## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
