### PR TITLE
fix: showing verifier config parse detail in err log

### DIFF
--- a/pkg/verifier/notation/notation.go
+++ b/pkg/verifier/notation/notation.go
@@ -101,7 +101,7 @@ func (f *notationPluginVerifierFactory) Create(_ string, verifierConfig config.V
 	}
 	conf, err := parseVerifierConfig(verifierConfig, namespace)
 	if err != nil {
-		return nil, re.ErrorCodeConfigInvalid.WithComponentType(re.Verifier).WithPluginName(verifierName)
+		return nil, re.ErrorCodeConfigInvalid.WithComponentType(re.Verifier).WithPluginName(verifierName).WithError(err)
 	}
 
 	verifyService, err := getVerifierService(conf, pluginDirectory)
@@ -235,6 +235,7 @@ func normalizeVerificationCertsStores(conf *NotationPluginVerifierConfig) error 
 		}
 	}
 	if isCertStoresByType && isLegacyCertStore {
+		logger.GetLogger(context.Background(), logOpt).Debugf("Get VerificationCertStores in mixed format")
 		return re.ErrorCodeConfigInvalid.NewError(re.Verifier, conf.Name, re.EmptyLink, nil, "both old VerificationCertStores and new VerificationCertStores are provided, please provide only one", re.HideStackTrace)
 	} else if !isCertStoresByType && isLegacyCertStore {
 		legacyCertStore, err := normalizeLegacyCertStore(conf)

--- a/pkg/verifier/notation/notation.go
+++ b/pkg/verifier/notation/notation.go
@@ -237,8 +237,10 @@ func normalizeVerificationCertsStores(conf *NotationPluginVerifierConfig) error 
 		}
 	}
 	if isCertStoresByType && isLegacyCertStore {
-		logger.GetLogger(context.Background(), logOpt).Error("Get VerificationCertStores in mixed format")
-		return re.ErrorCodeConfigInvalid.WithDetail("The verificationCertStores is misconfigured with both legacy and new formats").WithRemediation("Please provide only one format for the VerificationCertStores. Refer to the Notation Verifier configuration guide: https://ratify.dev/docs/plugins/verifier/notation#configuration")
+		// showing configuration content in the log with error details for better user experience
+		err := re.ErrorCodeConfigInvalid.WithDetail(fmt.Sprintf("The verificationCertStores is misconfigured with both legacy and new formats: %+v", conf)).WithRemediation("Please provide only one format for the VerificationCertStores. Refer to the Notation Verifier configuration guide: https://ratify.dev/docs/plugins/verifier/notation#configuration")
+		logger.GetLogger(context.Background(), logOpt).Error(err)
+		return err
 	} else if !isCertStoresByType && isLegacyCertStore {
 		legacyCertStore, err := normalizeLegacyCertStore(conf)
 		if err != nil {

--- a/pkg/verifier/notation/notation.go
+++ b/pkg/verifier/notation/notation.go
@@ -101,7 +101,7 @@ func (f *notationPluginVerifierFactory) Create(_ string, verifierConfig config.V
 	}
 	conf, err := parseVerifierConfig(verifierConfig, namespace)
 	if err != nil {
-		return nil, re.ErrorCodeConfigInvalid.WithComponentType(re.Verifier).WithPluginName(verifierName).WithError(err)
+		return nil, re.ErrorCodeConfigInvalid.WithError(err)
 	}
 
 	verifyService, err := getVerifierService(conf, pluginDirectory)
@@ -235,7 +235,7 @@ func normalizeVerificationCertsStores(conf *NotationPluginVerifierConfig) error 
 		}
 	}
 	if isCertStoresByType && isLegacyCertStore {
-		logger.GetLogger(context.Background(), logOpt).Debugf("Get VerificationCertStores in mixed format")
+		logger.GetLogger(context.Background(), logOpt).Error("Get VerificationCertStores in mixed format")
 		return re.ErrorCodeConfigInvalid.NewError(re.Verifier, conf.Name, re.EmptyLink, nil, "both old VerificationCertStores and new VerificationCertStores are provided, please provide only one", re.HideStackTrace)
 	} else if !isCertStoresByType && isLegacyCertStore {
 		legacyCertStore, err := normalizeLegacyCertStore(conf)

--- a/test/bats/tests/config/config_v1beta1_verifier_notation.yaml
+++ b/test/bats/tests/config/config_v1beta1_verifier_notation.yaml
@@ -9,7 +9,7 @@ spec:
     verificationCertStores:
       ca:
         ca-certs:
-        - certstore-inline
+          - certstore-inline
     trustPolicyDoc:
       version: "1.0"
       trustPolicies:


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
<!--Please include a summary of the changes and relevant context. -->

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

Showing verifier config parse error about using `VerificationCertStores` in mixed format in err log

## Type of change

Please delete options that are not relevant.
Before:
Screen Capture
![image](https://github.com/user-attachments/assets/c8525116-29b7-4547-ad2d-ea08286b7ff5)
Details
```
time=2024-09-10T12:50:33.130136555Z level=debug msg=creating notation with config map[artifactTypes:application/vnd.cncf.notary.signature name:verifier-notation trustPolicyDoc:map[trustPolicies:[map[name:default registryScopes:[*] signatureVerification:map[level:strict] trustStores:[ca:ca-certs] trustedIdentities:[*]]] version:1.0] type:notation verificationCertStores:map[ca:map[ca-certs:[certstore-inline]] certs:[ratify-notation-inline-cert]]], namespace '' component-type=verifier go.version=go1.21.10
time=2024-09-10T12:50:33.130257057Z level=error msg=Error: config invalid, Code: CONFIG_INVALID, Plugin Name: verifier-notation, Component Type: verifier unable to create verifier from verifier config
time=2024-09-10T12:50:33.130325558Z level=error msg=Error: config invalid, Code: CONFIG_INVALID, Plugin Name: verifier-notation, Component Type: verifierunable to create verifier from verifier crd
time=2024-09-10T12:50:33.135608041Z level=error msg=Reconciler error Verifier=verifier-notation controller=verifier controllerGroup=config.ratify.deislabs.io controllerKind=Verifier error=Error: config invalid, Code: CONFIG_INVALID, Plugin Name: verifier-notation, Component Type: verifier name=verifier-notation namespace= reconcileID=39a4c842-9f20-44f7-a25a-049cb3582754 stacktrace=goroutine 371 [running]:
runtime/debug.Stack()
```
After:
Screen Capture
![image](https://github.com/user-attachments/assets/554d281a-8f80-432d-a4b2-9854bbaea5d3)
Details
```
time=2024-09-10T12:46:30.633387288Z level=debug msg=creating Notation verifier with config map[artifactTypes:application/vnd.cncf.notary.signature name:verifier-notation trustPolicyDoc:map[trustPolicies:[map[name:default registryScopes:[*] signatureVerification:map[level:strict] trustStores:[ca:ca-certs] trustedIdentities:[*]]] version:1.0] type:notation verificationCertStores:map[ca:map[ca-certs:[certstore-inline]] certs:[ratify-notation-inline-cert]]], namespace '' component-type=verifier go.version=go1.22.7
time=2024-09-10T12:46:30.63350789Z level=debug msg=Get VerificationCertStores in legacy format component-type=verifier go.version=go1.22.7
time=2024-09-10T12:46:30.63351519Z level=error msg=Get VerificationCertStores in mixed format component-type=verifier go.version=go1.22.7
time=2024-09-10T12:46:30.63352709Z level=error msg=CONFIG_INVALID: Failed to create the Notation Verifier: The verificationCertStores is misconfigured with both legacy and new formats: Please provide only one format for the VerificationCertStores. Refer to the Notation Verifier configuration guide: https://ratify.dev/docs/plugins/verifier/notation#configuration unable to create verifier from verifier config
time=2024-09-10T12:46:30.633532391Z level=error msg=CONFIG_INVALID: Unable to create verifier from verifier CR: Failed to create the Notation Verifier: The verificationCertStores is misconfigured with both legacy and new formats: Please provide only one format for the VerificationCertStores. Refer to the Notation Verifier configuration guide: https://ratify.dev/docs/plugins/verifier/notation#configuration
time=2024-09-10T12:46:30.638637571Z level=error msg=Reconciler error Verifier=verifier-notation controller=verifier controllerGroup=config.ratify.deislabs.io controllerKind=Verifier error=CONFIG_INVALID: Unable to create verifier from verifier CR: Failed to create the Notation Verifier: The verificationCertStores is misconfigured with both legacy and new formats: Please provide only one format for the VerificationCertStores. Refer to the Notation Verifier configuration guide: https://ratify.dev/docs/plugins/verifier/notation#configuration name=verifier-notation namespace= reconcileID=cb08ddae-74df-4fb0-97b1-1a41221504fd stacktrace=goroutine 338 [running]:
runtime/debug.Stack()
```

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

-[x]  AKS test in my own fork.
![image](https://github.com/user-attachments/assets/33dd6d36-89e1-4238-a3c3-b8ca341ef86d)

ref: https://github.com/junczhu/ratify/actions/runs/10789084563/job/29921271326?pr=22
# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
