### PR TITLE
chore: Replace deprecated autorest SDK with azidentity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,10 @@ require (
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7
 	github.com/aliyun/credentials-go v1.3.11
 	github.com/aws/aws-sdk-go-v2 v1.32.4
+	github.com/aws/aws-sdk-go-v2 v1.32.3
+	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azcertificates v0.9.0
+	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.43
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.45
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.28.6
@@ -67,6 +71,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/AliyunContainerService/ack-ram-tool/pkg/credentials/alibabacloudsdkgo/helper v0.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.12 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.6 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7
 	github.com/aliyun/credentials-go v1.3.11
 	github.com/aws/aws-sdk-go-v2 v1.32.4
-	github.com/aws/aws-sdk-go-v2 v1.32.3
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azcertificates v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,14 @@ github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.2 h1:w
 github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.2/go.mod h1:zzmu18cpAinSbhC86oWd47nmgbb91Fl+Yac2PE8NdYk=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/azcertificates v0.9.0 h1:btEsytNrA4TG3edZnnUnzOz8W2MjOd6Bu3/7xyOXSOY=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/azcertificates v0.9.0/go.mod h1:5SlTxxL1U4LLipEr7pAbnu6Ck5y3aIEu4L/tVbGmpsY=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0 h1:m/sWOGCREuSBqg2htVQTBY8nOZpyajYztF0vUvSZTuM=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0/go.mod h1:Pu5Zksi2KrU7LPbZbNINx6fuVrUp/ffvpxdDj+i8LeE=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0 h1:xnO4sFyG8UH2fElBkcqLTOZsAajvKfnSlgBBW8dXYjw=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0/go.mod h1:XD3DIOOVgBCO03OleB1fHjgktVRFxlT++KwKgIOewdM=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 h1:FbH3BbSb4bvGluTesZZ+ttN/MDsnMmQP36OSnDuSXqw=
+github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.1.0 h1:DRiANoJTiW6obBQe3SqZizkuV1PEgfiiGivmVocDy64=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.1.0/go.mod h1:qLIye2hwb/ZouqhpSD9Zn3SJipvpEnz1Ywl3VUk9Y0s=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.0.0 h1:D3occbWoio4EBLkbkevetNMAVX197GkzbUMtqjGWn80=

--- a/pkg/certificateprovider/azurekeyvault/auth.go
+++ b/pkg/certificateprovider/azurekeyvault/auth.go
@@ -35,44 +35,6 @@ const (
 	DefaultTokenAudience = "api://AzureADTokenExchange" //nolint
 )
 
-// authResult contains the subset of results from token acquisition operation in ConfidentialClientApplication
-// For details see https://aka.ms/msal-net-authenticationresult
-type authResult struct {
-	accessToken    string
-	expiresOn      time.Time
-	grantedScopes  []string
-	declinedScopes []string
-}
-
-// func getAuthorizerForWorkloadIdentity(ctx context.Context, tenantID, clientID, resource string) (autorest.Authorizer, error) {
-// 	scope := resource
-// 	// .default needs to be added to the scope
-// 	if !strings.Contains(resource, ".default") {
-// 		scope = fmt.Sprintf("%s/.default", resource)
-// 	}
-
-// 	result, err := azureauth.GetAADAccessToken(ctx, tenantID, clientID, scope)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to acquire token: %w", err)
-// 	}
-
-// 	if _, err = parseExpiresOn(result.ExpiresOn.UTC().Local().Format(expiresOnDateFormat)); err != nil {
-// 		return nil, fmt.Errorf("failed to parse expires_on: %w", err)
-// 	}
-
-// 	return autorest.NewBearerAuthorizer(authResult{
-// 		accessToken:    result.AccessToken,
-// 		expiresOn:      result.ExpiresOn,
-// 		grantedScopes:  result.GrantedScopes,
-// 		declinedScopes: result.DeclinedScopes,
-// 	}), nil
-// }
-
-// OAuthToken implements the OAuthTokenProvider interface.  It returns the current access token.
-func (ar authResult) OAuthToken() string {
-	return ar.accessToken
-}
-
 // Vendored from https://github.com/Azure/go-autorest/blob/79575dd7ba2e88e7ce7ab84e167ec6653dcb70c1/autorest/adal/token.go
 // converts expires_on to the number of seconds
 func parseExpiresOn(s interface{}) (json.Number, error) {

--- a/pkg/certificateprovider/azurekeyvault/auth.go
+++ b/pkg/certificateprovider/azurekeyvault/auth.go
@@ -18,16 +18,10 @@ package azurekeyvault
 // This class is based on implementation from  azure secret store csi provider
 // Source: https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/release-1.4/pkg/auth
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
-
-	"github.com/ratify-project/ratify/pkg/utils/azureauth"
-
-	"github.com/Azure/go-autorest/autorest"
 )
 
 const (
@@ -50,29 +44,29 @@ type authResult struct {
 	declinedScopes []string
 }
 
-func getAuthorizerForWorkloadIdentity(ctx context.Context, tenantID, clientID, resource string) (autorest.Authorizer, error) {
-	scope := resource
-	// .default needs to be added to the scope
-	if !strings.Contains(resource, ".default") {
-		scope = fmt.Sprintf("%s/.default", resource)
-	}
+// func getAuthorizerForWorkloadIdentity(ctx context.Context, tenantID, clientID, resource string) (autorest.Authorizer, error) {
+// 	scope := resource
+// 	// .default needs to be added to the scope
+// 	if !strings.Contains(resource, ".default") {
+// 		scope = fmt.Sprintf("%s/.default", resource)
+// 	}
 
-	result, err := azureauth.GetAADAccessToken(ctx, tenantID, clientID, scope)
-	if err != nil {
-		return nil, fmt.Errorf("failed to acquire token: %w", err)
-	}
+// 	result, err := azureauth.GetAADAccessToken(ctx, tenantID, clientID, scope)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to acquire token: %w", err)
+// 	}
 
-	if _, err = parseExpiresOn(result.ExpiresOn.UTC().Local().Format(expiresOnDateFormat)); err != nil {
-		return nil, fmt.Errorf("failed to parse expires_on: %w", err)
-	}
+// 	if _, err = parseExpiresOn(result.ExpiresOn.UTC().Local().Format(expiresOnDateFormat)); err != nil {
+// 		return nil, fmt.Errorf("failed to parse expires_on: %w", err)
+// 	}
 
-	return autorest.NewBearerAuthorizer(authResult{
-		accessToken:    result.AccessToken,
-		expiresOn:      result.ExpiresOn,
-		grantedScopes:  result.GrantedScopes,
-		declinedScopes: result.DeclinedScopes,
-	}), nil
-}
+// 	return autorest.NewBearerAuthorizer(authResult{
+// 		accessToken:    result.AccessToken,
+// 		expiresOn:      result.ExpiresOn,
+// 		grantedScopes:  result.GrantedScopes,
+// 		declinedScopes: result.DeclinedScopes,
+// 	}), nil
+// }
 
 // OAuthToken implements the OAuthTokenProvider interface.  It returns the current access token.
 func (ar authResult) OAuthToken() string {

--- a/pkg/certificateprovider/azurekeyvault/provider.go
+++ b/pkg/certificateprovider/azurekeyvault/provider.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ratify-project/ratify/pkg/certificateprovider"
 	"github.com/ratify-project/ratify/pkg/certificateprovider/azurekeyvault/types"
 	"github.com/ratify-project/ratify/pkg/metrics"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/pkcs12"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -213,8 +212,6 @@ func parseAzureEnvironment(cloudName string) (*azure.Environment, error) {
 func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientID string) (*azsecrets.Client, error) {
 	// Trim any trailing slash from the endpoint
 	kvEndpoint := strings.TrimSuffix(keyVaultEndpoint, "/")
-	logger.GetLogger(ctx, logOpt).Infof("kvEndpoint: '%s'", kvEndpoint)
-	logrus.WithContext(ctx).Infof("kvEndpoint: '%s'", kvEndpoint)
 
 	// Create the workload identity credential for authentication
 	credential, err := azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
@@ -224,7 +221,6 @@ func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientI
 	if err != nil {
 		return nil, re.ErrorCodeAuthDenied.WithDetail("failed to create workload identity credential").WithRemediation(re.AKVLink).WithError(err)
 	}
-	logger.GetLogger(ctx, logOpt).Infof("credential created successfully")
 
 	// create azsecrets client
 	kvClientSecrets, err := azsecrets.NewClient(kvEndpoint, credential, nil)

--- a/pkg/certificateprovider/azurekeyvault/provider.go
+++ b/pkg/certificateprovider/azurekeyvault/provider.go
@@ -109,9 +109,6 @@ func (s *akvCertProvider) GetCertificates(ctx context.Context, attrib map[string
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get secret objectName:%s, objectVersion:%s, error: %w", keyVaultCert.CertificateName, keyVaultCert.CertificateVersion, err)
 		}
-		if reflect.DeepEqual(secretResponse, azsecrets.GetSecretResponse{}) {
-			return nil, nil, fmt.Errorf("failed to get secret objectName:%s, objectVersion:%s, secret response is empty", keyVaultCert.CertificateName, keyVaultCert.CertificateVersion)
-		}
 		secretBundle := secretResponse.SecretBundle
 
 		certResult, certProperty, err := getCertsFromSecretBundle(ctx, secretBundle, keyVaultCert.CertificateName)

--- a/pkg/certificateprovider/azurekeyvault/provider.go
+++ b/pkg/certificateprovider/azurekeyvault/provider.go
@@ -109,6 +109,9 @@ func (s *akvCertProvider) GetCertificates(ctx context.Context, attrib map[string
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get secret objectName:%s, objectVersion:%s, error: %w", keyVaultCert.CertificateName, keyVaultCert.CertificateVersion, err)
 		}
+		if reflect.DeepEqual(secretResponse, azsecrets.GetSecretResponse{}) {
+			return nil, nil, fmt.Errorf("failed to get secret objectName:%s, objectVersion:%s, secret response is empty", keyVaultCert.CertificateName, keyVaultCert.CertificateVersion)
+		}
 		secretBundle := secretResponse.SecretBundle
 
 		certResult, certProperty, err := getCertsFromSecretBundle(ctx, secretBundle, keyVaultCert.CertificateName)
@@ -204,14 +207,14 @@ func initializeKvClient(keyVaultEndpoint, tenantID, clientID string, credProvide
 			TenantID: tenantID,
 		})
 		if err != nil {
-			return nil, re.ErrorCodeAuthDenied.WithDetail("failed to create workload identity credential").WithRemediation(re.AKVLink).WithError(err)
+			return nil, re.ErrorCodeAuthDenied.WithDetail("failed to create workload identity credential").WithError(err)
 		}
 	}
 
 	// create azsecrets client
 	secretKVClient, err := azsecrets.NewClient(kvEndpoint, credProvider, nil)
 	if err != nil {
-		return nil, re.ErrorCodeConfigInvalid.WithDetail("Failed to create Key Vault client").WithRemediation(re.AKVLink).WithError(err)
+		return nil, re.ErrorCodeConfigInvalid.WithDetail("Failed to create Key Vault client").WithError(err)
 	}
 
 	return secretKVClient, nil

--- a/pkg/certificateprovider/azurekeyvault/provider.go
+++ b/pkg/certificateprovider/azurekeyvault/provider.go
@@ -81,7 +81,7 @@ func (s *akvCertProvider) GetCertificates(ctx context.Context, attrib map[string
 		return nil, nil, re.ErrorCodeConfigInvalid.NewError(re.CertProvider, providerName, re.AKVLink, nil, "clientID is not set", re.HideStackTrace)
 	}
 
-	azureCloudEnv, err := parseAzureEnvironment(cloudName)
+	_, err := parseAzureEnvironment(cloudName)
 	if err != nil {
 		return nil, nil, re.ErrorCodeConfigInvalid.NewError(re.CertProvider, providerName, re.EmptyLink, nil, fmt.Sprintf("cloudName %s is not valid", cloudName), re.HideStackTrace)
 	}
@@ -97,7 +97,7 @@ func (s *akvCertProvider) GetCertificates(ctx context.Context, attrib map[string
 
 	logger.GetLogger(ctx, logOpt).Debugf("vaultURI %s", keyvaultURI)
 
-	kvClientSecrets, err := initializeKvClient(ctx, azureCloudEnv.KeyVaultEndpoint, tenantID, workloadIdentityClientID, nil)
+	kvClientSecrets, err := initializeKvClient(ctx, keyvaultURI, tenantID, workloadIdentityClientID, nil)
 	if err != nil {
 		return nil, nil, re.ErrorCodePluginInitFailure.NewError(re.CertProvider, providerName, re.AKVLink, err, "failed to get keyvault client", re.HideStackTrace)
 	}
@@ -231,7 +231,7 @@ func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientI
 	if err != nil {
 		return nil, re.ErrorCodeConfigInvalid.WithDetail("Failed to create Key Vault client").WithRemediation(re.AKVLink).WithError(err)
 	}
-	logger.GetLogger(ctx, logOpt).Infof("azsecrets kvclient created successfully")
+	logger.GetLogger(ctx, logOpt).Debugf("azsecrets kvclient created successfully")
 
 	return kvClientSecrets, nil
 }

--- a/pkg/certificateprovider/azurekeyvault/provider.go
+++ b/pkg/certificateprovider/azurekeyvault/provider.go
@@ -96,7 +96,7 @@ func (s *akvCertProvider) GetCertificates(ctx context.Context, attrib map[string
 
 	logger.GetLogger(ctx, logOpt).Debugf("vaultURI %s", keyvaultURI)
 
-	kvClientSecrets, err := initializeKvClient(ctx, azureCloudEnv.KeyVaultEndpoint, tenantID, workloadIdentityClientID)
+	kvClientSecrets, err := initializeKvClient(azureCloudEnv.KeyVaultEndpoint, tenantID, workloadIdentityClientID)
 	if err != nil {
 		return nil, nil, re.ErrorCodePluginInitFailure.NewError(re.CertProvider, providerName, re.AKVLink, err, "failed to get keyvault client", re.HideStackTrace)
 	}
@@ -209,7 +209,7 @@ func parseAzureEnvironment(cloudName string) (*azure.Environment, error) {
 	return &env, err
 }
 
-func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientID string) (*azsecrets.Client, error) {
+func initializeKvClient(keyVaultEndpoint, tenantID, clientID string) (*azsecrets.Client, error) {
 	// Trim any trailing slash from the endpoint
 	kvEndpoint := strings.TrimSuffix(keyVaultEndpoint, "/")
 

--- a/pkg/certificateprovider/azurekeyvault/provider_test.go
+++ b/pkg/certificateprovider/azurekeyvault/provider_test.go
@@ -206,15 +206,6 @@ func TestGetCertificates(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			desc: "invalid cloud name",
-			parameters: map[string]string{
-				"vaultUri":  "https://testkv.vault.azure.net/",
-				"tenantID":  "tid",
-				"cloudName": "AzureCloud",
-			},
-			expectedErr: true,
-		},
-		{
 			desc: "certificates array not set",
 			parameters: map[string]string{
 				"vaultUri":             "https://testkv.vault.azure.net/",
@@ -329,7 +320,6 @@ func TestGetKeyvaultRequestObj(t *testing.T) {
 	attrib := map[string]string{}
 	attrib["vaultURI"] = "https://testvault.vault.azure.net/"
 	attrib["clientID"] = "TestClient"
-	attrib["cloudName"] = "TestCloud"
 	attrib["tenantID"] = "TestIDABC"
 	attrib["certificates"] = "array:\n- |\n  certificateName: wabbit-networks-io  \n  certificateVersion: \"testversion\"\n"
 

--- a/pkg/certificateprovider/azurekeyvault/provider_test.go
+++ b/pkg/certificateprovider/azurekeyvault/provider_test.go
@@ -101,7 +101,7 @@ func SkipTestInitializeKVClient(t *testing.T) {
 	}
 
 	for i := range testEnvs {
-		kvClientSecrets, err := initializeKvClient(testEnvs[i].KeyVaultEndpoint, "", "")
+		kvClientSecrets, err := initializeKvClient(context.TODO(), testEnvs[i].KeyVaultEndpoint, "", "")
 		assert.NoError(t, err)
 		assert.NotNil(t, kvClientSecrets)
 		// assert.NotNil(t, kvBaseClient.Authorizer)

--- a/pkg/certificateprovider/azurekeyvault/provider_test.go
+++ b/pkg/certificateprovider/azurekeyvault/provider_test.go
@@ -144,7 +144,7 @@ func TestInitializeKvClient(t *testing.T) {
 			mockSecretsClient.On("NewClient", tt.kvEndpoint, mockCredential, mock.Anything).Return(mockSecretsClient, tt.mockSecretsErr)
 
 			// Call function under test
-			secretsClient, err := initializeKvClient(context.Background(), tt.kvEndpoint, tt.tenantID, tt.clientID, nil)
+			secretsClient, err := initializeKvClient(tt.kvEndpoint, tt.tenantID, tt.clientID, nil)
 
 			// Validate expectations
 			if tt.expectedErr {
@@ -160,7 +160,6 @@ func TestInitializeKvClient(t *testing.T) {
 
 func TestInitializeKvClient_Success(t *testing.T) {
 	// Mock the context and input parameters
-	ctx := context.Background()
 	keyVaultEndpoint := "https://myvault.vault.azure.net/"
 	tenantID := "tenant-id"
 	clientID := "client-id"
@@ -172,7 +171,7 @@ func TestInitializeKvClient_Success(t *testing.T) {
 	}
 
 	// Run the function with the mock credential
-	kvClientSecrets, err := initializeKvClient(ctx, keyVaultEndpoint, tenantID, clientID, mockCredential)
+	kvClientSecrets, err := initializeKvClient(keyVaultEndpoint, tenantID, clientID, mockCredential)
 
 	// Assert the function succeeds without errors and clients are created
 	assert.NotNil(t, kvClientSecrets)

--- a/pkg/certificateprovider/azurekeyvault/provider_test.go
+++ b/pkg/certificateprovider/azurekeyvault/provider_test.go
@@ -101,7 +101,7 @@ func SkipTestInitializeKVClient(t *testing.T) {
 	}
 
 	for i := range testEnvs {
-		kvClientSecrets, err := initializeKvClient(context.TODO(), testEnvs[i].KeyVaultEndpoint, "", "")
+		kvClientSecrets, err := initializeKvClient(testEnvs[i].KeyVaultEndpoint, "", "")
 		assert.NoError(t, err)
 		assert.NotNil(t, kvClientSecrets)
 		// assert.NotNil(t, kvBaseClient.Authorizer)

--- a/pkg/certificateprovider/azurekeyvault/provider_test.go
+++ b/pkg/certificateprovider/azurekeyvault/provider_test.go
@@ -24,9 +24,8 @@ import (
 	"testing"
 	"time"
 
-	kv "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
+	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/ratify-project/ratify/internal/version"
 	"github.com/ratify-project/ratify/pkg/certificateprovider/azurekeyvault/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -102,11 +101,11 @@ func SkipTestInitializeKVClient(t *testing.T) {
 	}
 
 	for i := range testEnvs {
-		kvBaseClient, err := initializeKvClient(context.TODO(), testEnvs[i].KeyVaultEndpoint, "", "")
+		kvClientSecrets, err := initializeKvClient(context.TODO(), testEnvs[i].KeyVaultEndpoint, "", "")
 		assert.NoError(t, err)
-		assert.NotNil(t, kvBaseClient)
-		assert.NotNil(t, kvBaseClient.Authorizer)
-		assert.Contains(t, kvBaseClient.UserAgent, version.UserAgent)
+		assert.NotNil(t, kvClientSecrets)
+		// assert.NotNil(t, kvBaseClient.Authorizer)
+		// assert.Contains(t, kvClientSecrets.endpoint, testEnvs[i].KeyVaultEndpoint)
 	}
 }
 
@@ -280,7 +279,7 @@ func Test(t *testing.T) {
 		desc        string
 		value       string
 		contentType string
-		id          string
+		id          azsecrets.ID
 		expectedErr bool
 	}{
 		{
@@ -322,7 +321,7 @@ func Test(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			testdata := kv.SecretBundle{
+			testdata := azsecrets.SecretBundle{
 				Value:       &cases[i].value,
 				ID:          &cases[i].id,
 				ContentType: &cases[i].contentType,

--- a/pkg/certificateprovider/azurekeyvault/provider_test.go
+++ b/pkg/certificateprovider/azurekeyvault/provider_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -32,27 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
-
-func TestParseAzureEnvironment(t *testing.T) {
-	envNamesArray := []string{"AZURECHINACLOUD", "AZUREGERMANCLOUD", "AZUREPUBLICCLOUD", "AZUREUSGOVERNMENTCLOUD", ""}
-	for _, envName := range envNamesArray {
-		azureEnv, err := parseAzureEnvironment(envName)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-		if strings.EqualFold(envName, "") && !strings.EqualFold(azureEnv.Name, "AZUREPUBLICCLOUD") {
-			t.Fatalf("string doesn't match, expected AZUREPUBLICCLOUD, got %s", azureEnv.Name)
-		} else if !strings.EqualFold(envName, "") && !strings.EqualFold(envName, azureEnv.Name) {
-			t.Fatalf("string doesn't match, expected %s, got %s", envName, azureEnv.Name)
-		}
-	}
-
-	wrongEnvName := "AZUREWRONGCLOUD"
-	_, err := parseAzureEnvironment(wrongEnvName)
-	if err == nil {
-		t.Fatalf("expected error for wrong azure environment name")
-	}
-}
 
 func TestFormatKeyVaultCertificate(t *testing.T) {
 	cases := []struct {

--- a/pkg/certificateprovider/azurekeyvault/provider_test.go
+++ b/pkg/certificateprovider/azurekeyvault/provider_test.go
@@ -166,7 +166,7 @@ func TestInitializeKvClient(t *testing.T) {
 			mockSecretsClient.On("NewClient", tt.kvEndpoint, mockCredential, mock.Anything).Return(mockSecretsClient, tt.mockSecretsErr)
 
 			// Call function under test
-			secretsClient, err := initializeKvClient(context.Background(), tt.kvEndpoint, tt.tenantID, tt.clientID)
+			secretsClient, err := initializeKvClient(context.Background(), tt.kvEndpoint, tt.tenantID, tt.clientID, nil)
 
 			// Validate expectations
 			if tt.expectedErr {
@@ -178,6 +178,27 @@ func TestInitializeKvClient(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInitializeKvClient_Success(t *testing.T) {
+	// Mock the context and input parameters
+	ctx := context.Background()
+	keyVaultEndpoint := "https://myvault.vault.azure.net/"
+	tenantID := "tenant-id"
+	clientID := "client-id"
+
+	// Create a mock credential provider
+	mockCredential, err := azidentity.NewClientSecretCredential(tenantID, clientID, "fake-secret", nil)
+	if err != nil {
+		t.Fatalf("Failed to create mock credential: %v", err)
+	}
+
+	// Run the function with the mock credential
+	kvClientSecrets, err := initializeKvClient(ctx, keyVaultEndpoint, tenantID, clientID, mockCredential)
+
+	// Assert the function succeeds without errors and clients are created
+	assert.NotNil(t, kvClientSecrets)
+	assert.NoError(t, err)
 }
 
 func TestGetCertificates(t *testing.T) {

--- a/pkg/keymanagementprovider/azurekeyvault/auth.go
+++ b/pkg/keymanagementprovider/azurekeyvault/auth.go
@@ -35,44 +35,6 @@ const (
 	DefaultTokenAudience = "api://AzureADTokenExchange" //nolint
 )
 
-// authResult contains the subset of results from token acquisition operation in ConfidentialClientApplication
-// For details see https://aka.ms/msal-net-authenticationresult
-type authResult struct {
-	accessToken    string
-	expiresOn      time.Time
-	grantedScopes  []string
-	declinedScopes []string
-}
-
-// func getAuthorizerForWorkloadIdentity(ctx context.Context, tenantID, clientID, resource string) (autorest.Authorizer, error) {
-// 	scope := resource
-// 	// .default needs to be added to the scope
-// 	if !strings.Contains(resource, ".default") {
-// 		scope = fmt.Sprintf("%s/.default", resource)
-// 	}
-
-// 	result, err := azureauth.GetAADAccessToken(ctx, tenantID, clientID, scope)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to acquire token: %w", err)
-// 	}
-
-// 	if _, err = parseExpiresOn(result.ExpiresOn.UTC().Local().Format(expiresOnDateFormat)); err != nil {
-// 		return nil, fmt.Errorf("failed to parse expires_on: %w", err)
-// 	}
-
-// 	return autorest.NewBearerAuthorizer(authResult{
-// 		accessToken:    result.AccessToken,
-// 		expiresOn:      result.ExpiresOn,
-// 		grantedScopes:  result.GrantedScopes,
-// 		declinedScopes: result.DeclinedScopes,
-// 	}), nil
-// }
-
-// OAuthToken implements the OAuthTokenProvider interface.  It returns the current access token.
-func (ar authResult) OAuthToken() string {
-	return ar.accessToken
-}
-
 // Vendored from https://github.com/Azure/go-autorest/blob/79575dd7ba2e88e7ce7ab84e167ec6653dcb70c1/autorest/adal/token.go
 // converts expires_on to the number of seconds
 func parseExpiresOn(s interface{}) (json.Number, error) {

--- a/pkg/keymanagementprovider/azurekeyvault/auth.go
+++ b/pkg/keymanagementprovider/azurekeyvault/auth.go
@@ -18,16 +18,10 @@ package azurekeyvault
 // This class is based on implementation from  azure secret store csi provider
 // Source: https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/release-1.4/pkg/auth
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
-
-	"github.com/ratify-project/ratify/pkg/utils/azureauth"
-
-	"github.com/Azure/go-autorest/autorest"
 )
 
 const (
@@ -50,29 +44,29 @@ type authResult struct {
 	declinedScopes []string
 }
 
-func getAuthorizerForWorkloadIdentity(ctx context.Context, tenantID, clientID, resource string) (autorest.Authorizer, error) {
-	scope := resource
-	// .default needs to be added to the scope
-	if !strings.Contains(resource, ".default") {
-		scope = fmt.Sprintf("%s/.default", resource)
-	}
+// func getAuthorizerForWorkloadIdentity(ctx context.Context, tenantID, clientID, resource string) (autorest.Authorizer, error) {
+// 	scope := resource
+// 	// .default needs to be added to the scope
+// 	if !strings.Contains(resource, ".default") {
+// 		scope = fmt.Sprintf("%s/.default", resource)
+// 	}
 
-	result, err := azureauth.GetAADAccessToken(ctx, tenantID, clientID, scope)
-	if err != nil {
-		return nil, fmt.Errorf("failed to acquire token: %w", err)
-	}
+// 	result, err := azureauth.GetAADAccessToken(ctx, tenantID, clientID, scope)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to acquire token: %w", err)
+// 	}
 
-	if _, err = parseExpiresOn(result.ExpiresOn.UTC().Local().Format(expiresOnDateFormat)); err != nil {
-		return nil, fmt.Errorf("failed to parse expires_on: %w", err)
-	}
+// 	if _, err = parseExpiresOn(result.ExpiresOn.UTC().Local().Format(expiresOnDateFormat)); err != nil {
+// 		return nil, fmt.Errorf("failed to parse expires_on: %w", err)
+// 	}
 
-	return autorest.NewBearerAuthorizer(authResult{
-		accessToken:    result.AccessToken,
-		expiresOn:      result.ExpiresOn,
-		grantedScopes:  result.GrantedScopes,
-		declinedScopes: result.DeclinedScopes,
-	}), nil
-}
+// 	return autorest.NewBearerAuthorizer(authResult{
+// 		accessToken:    result.AccessToken,
+// 		expiresOn:      result.ExpiresOn,
+// 		grantedScopes:  result.GrantedScopes,
+// 		declinedScopes: result.DeclinedScopes,
+// 	}), nil
+// }
 
 // OAuthToken implements the OAuthTokenProvider interface.  It returns the current access token.
 func (ar authResult) OAuthToken() string {

--- a/pkg/keymanagementprovider/azurekeyvault/provider.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider.go
@@ -38,7 +38,6 @@ import (
 	"github.com/ratify-project/ratify/pkg/keymanagementprovider/config"
 	"github.com/ratify-project/ratify/pkg/keymanagementprovider/factory"
 	"github.com/ratify-project/ratify/pkg/metrics"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/pkcs12"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -297,8 +296,6 @@ func parseAzureEnvironment(cloudName string) (*azure.Environment, error) {
 func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientID string) (*azkeys.Client, *azsecrets.Client, error) {
 	// Trim any trailing slash from the endpoint
 	kvEndpoint := strings.TrimSuffix(keyVaultEndpoint, "/")
-	logger.GetLogger(ctx, logOpt).Infof("kvEndpoint: '%s'", kvEndpoint)
-	logrus.WithContext(ctx).Infof("kvEndpoint: '%s'", kvEndpoint)
 
 	// Create the workload identity credential for authentication
 	credential, err := azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
@@ -308,8 +305,6 @@ func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientI
 	if err != nil {
 		return nil, nil, re.ErrorCodeAuthDenied.WithDetail("failed to create workload identity credential").WithRemediation(re.AKVLink).WithError(err)
 	}
-	logger.GetLogger(ctx, logOpt).Infof("credential created successfully")
-	logrus.WithContext(ctx).Infof("credential created successfully")
 
 	// create azkeys client
 	kvClientKeys, err := azkeys.NewClient(kvEndpoint, credential, nil)
@@ -317,14 +312,13 @@ func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientI
 		return nil, nil, re.ErrorCodeConfigInvalid.WithDetail("Failed to create Key Vault client").WithRemediation(re.AKVLink).WithError(err)
 	}
 	logger.GetLogger(ctx, logOpt).Infof("azkeys kvclient created successfully")
-	logrus.WithContext(ctx).Infof("azkeys kvclient created successfully")
+
 	// create azsecrets client
 	kvClientSecrets, err := azsecrets.NewClient(kvEndpoint, credential, nil)
 	if err != nil {
 		return nil, nil, re.ErrorCodeConfigInvalid.WithDetail("Failed to create Key Vault client").WithRemediation(re.AKVLink).WithError(err)
 	}
 	logger.GetLogger(ctx, logOpt).Infof("azsecrets kvclient created successfully")
-	logrus.WithContext(ctx).Infof("azsecrets kvclient created successfully")
 
 	return kvClientKeys, kvClientSecrets, nil
 }

--- a/pkg/keymanagementprovider/azurekeyvault/provider.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider.go
@@ -459,16 +459,18 @@ func isSecretDisabledError(err error) bool {
 	const SecretDisabledCode = "SecretDisabled"
 	var httpErr *azcore.ResponseError
 	if errors.As(err, &httpErr) {
-		if httpErr.StatusCode == http.StatusForbidden {
-			var azureError AzureError
-			errorResponseBody, readErr := io.ReadAll(httpErr.RawResponse.Body)
-			if readErr != nil {
-				return false
-			}
-			jsonErr := json.Unmarshal(errorResponseBody, &azureError)
-			if jsonErr == nil && azureError.Error.Code == ErrorCodeForbidden && azureError.Error.InnerError.Code == SecretDisabledCode {
-				return true
-			}
+		if httpErr.StatusCode != http.StatusForbidden {
+			return false
+		}
+
+		var azureError AzureError
+		errorResponseBody, readErr := io.ReadAll(httpErr.RawResponse.Body)
+		if readErr != nil {
+			return false
+		}
+		jsonErr := json.Unmarshal(errorResponseBody, &azureError)
+		if jsonErr == nil && azureError.Error.Code == ErrorCodeForbidden && azureError.Error.InnerError.Code == SecretDisabledCode {
+			return true
 		}
 	}
 

--- a/pkg/keymanagementprovider/azurekeyvault/provider.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider.go
@@ -311,7 +311,6 @@ func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientI
 	if err != nil {
 		return nil, nil, re.ErrorCodeConfigInvalid.WithDetail("Failed to create Key Vault client").WithRemediation(re.AKVLink).WithError(err)
 	}
-	logger.GetLogger(ctx, logOpt).Infof("azkeys kvclient created successfully")
 
 	// create azsecrets client
 	kvClientSecrets, err := azsecrets.NewClient(kvEndpoint, credential, nil)

--- a/pkg/keymanagementprovider/azurekeyvault/provider.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider.go
@@ -78,7 +78,6 @@ type akvKMProvider struct {
 	resource        string
 	certificates    []types.KeyVaultValue
 	keys            []types.KeyVaultValue
-	cloudEnv        *azure.Environment
 	kvClientKeys    *azkeys.Client
 	kvClientSecrets *azsecrets.Client
 }
@@ -134,11 +133,6 @@ func (f *akvKMProviderFactory) Create(_ string, keyManagementProviderConfig conf
 
 	if err := json.Unmarshal(keyManagementProviderConfigBytes, &conf); err != nil {
 		return nil, re.ErrorCodeConfigInvalid.NewError(re.KeyManagementProvider, "", re.EmptyLink, err, "failed to parse AKV key management provider configuration", re.HideStackTrace)
-	}
-
-	azureCloudEnv, err := parseAzureEnvironment(conf.CloudName)
-	if err != nil {
-		return nil, re.ErrorCodeConfigInvalid.NewError(re.KeyManagementProvider, ProviderName, re.EmptyLink, nil, fmt.Sprintf("cloudName %s is not valid", conf.CloudName), re.HideStackTrace)
 	}
 
 	if len(conf.Certificates) == 0 && len(conf.Keys) == 0 {
@@ -279,18 +273,6 @@ func getStatusProperty(name, version, lastRefreshed string, enabled bool) map[st
 	properties[types.StatusEnabled] = strconv.FormatBool(enabled)
 	properties[types.StatusLastRefreshed] = lastRefreshed
 	return properties
-}
-
-// parseAzureEnvironment returns azure environment by name
-func parseAzureEnvironment(cloudName string) (*azure.Environment, error) {
-	var env azure.Environment
-	var err error
-	if cloudName == "" {
-		env = azure.PublicCloud
-	} else {
-		env, err = azure.EnvironmentFromName(cloudName)
-	}
-	return &env, err
 }
 
 func initializeKvClient(ctx context.Context, keyVaultURI, tenantID, clientID string, credProvider azcore.TokenCredential) (*azkeys.Client, *azsecrets.Client, error) {

--- a/pkg/keymanagementprovider/azurekeyvault/provider.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider.go
@@ -443,6 +443,7 @@ func getObjectVersion(id string) string {
 
 func isSecretDisabledError(err error) bool {
 	// AzureError defines the structure of the error response from Azure Key Vault
+	// This structure is defined according to https://learn.microsoft.com/en-us/rest/api/keyvault/keys/get-keys/get-keys?view=rest-keyvault-keys-7.4&tabs=HTTP#error
 	type AzureError struct {
 		Error struct {
 			Code       string `json:"code"`
@@ -465,10 +466,8 @@ func isSecretDisabledError(err error) bool {
 				return false
 			}
 			jsonErr := json.Unmarshal(errorResponseBody, &azureError)
-			if jsonErr == nil {
-				if azureError.Error.Code == ErrorCodeForbidden && azureError.Error.InnerError.Code == SecretDisabledCode {
-					return true
-				}
+			if jsonErr == nil && azureError.Error.Code == ErrorCodeForbidden && azureError.Error.InnerError.Code == SecretDisabledCode {
+				return true
 			}
 		}
 	}

--- a/pkg/keymanagementprovider/azurekeyvault/provider.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -195,9 +194,6 @@ func (s *akvKMProvider) GetCertificates(ctx context.Context) (map[keymanagementp
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to get certificate objectName:%s, objectVersion:%s, error: %w", keyVaultCert.Name, keyVaultCert.Version, err)
 				}
-				if reflect.DeepEqual(certResponse, azcertificates.GetCertificateResponse{}) {
-					return nil, nil, fmt.Errorf("failed to get certificate objectName:%s, objectVersion:%s, certificate response is nil", keyVaultCert.Name, keyVaultCert.Version)
-				}
 				certBundle := certResponse.CertificateBundle
 				keyVaultCert.Version = getObjectVersion(*certBundle.KID)
 				isEnabled := *certBundle.Attributes.Enabled
@@ -211,9 +207,6 @@ func (s *akvKMProvider) GetCertificates(ctx context.Context) (map[keymanagementp
 			return nil, nil, fmt.Errorf("failed to get secret objectName:%s, objectVersion:%s, error: %w", keyVaultCert.Name, keyVaultCert.Version, err)
 		}
 
-		if reflect.DeepEqual(secretResponse, azsecrets.GetSecretResponse{}) {
-			return nil, nil, fmt.Errorf("failed to get secret objectName:%s, objectVersion:%s, secret response is nil", keyVaultCert.Name, keyVaultCert.Version)
-		}
 		secretBundle := secretResponse.SecretBundle
 		isEnabled := *secretBundle.Attributes.Enabled
 
@@ -244,11 +237,7 @@ func (s *akvKMProvider) GetKeys(ctx context.Context) (map[keymanagementprovider.
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get key objectName:%s, objectVersion:%s, error: %w", keyVaultKey.Name, keyVaultKey.Version, err)
 		}
-		if reflect.DeepEqual(keyResponse, azkeys.GetKeyResponse{}) {
-			return nil, nil, fmt.Errorf("failed to get key objectName:%s, objectVersion:%s, key response is nil", keyVaultKey.Name, keyVaultKey.Version)
-		}
 		keyBundle := keyResponse.KeyBundle
-
 		isEnabled := *keyBundle.Attributes.Enabled
 		// if version is set as "" in the config, use the version from the key bundle
 		keyVaultKey.Version = getObjectVersion(string(*keyBundle.Key.KID))

--- a/pkg/keymanagementprovider/azurekeyvault/provider.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider.go
@@ -294,7 +294,6 @@ func parseAzureEnvironment(cloudName string) (*azure.Environment, error) {
 }
 
 func initializeKvClient(keyVaultEndpoint, tenantID, clientID string) (*azkeys.Client, *azsecrets.Client, error) {
-
 	// Trim any trailing slash from the endpoint
 	kvEndpoint := strings.TrimSuffix(keyVaultEndpoint, "/")
 

--- a/pkg/keymanagementprovider/azurekeyvault/provider.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider.go
@@ -161,7 +161,7 @@ func (f *akvKMProviderFactory) Create(_ string, keyManagementProviderConfig conf
 
 	logger.GetLogger(context.Background(), logOpt).Debugf("vaultURI %s", provider.vaultURI)
 
-	kvClientKeys, kvClientSecrets, err := initKVClient(context.Background(), provider.cloudEnv.KeyVaultEndpoint, provider.tenantID, provider.clientID)
+	kvClientKeys, kvClientSecrets, err := initKVClient(provider.cloudEnv.KeyVaultEndpoint, provider.tenantID, provider.clientID)
 	if err != nil {
 		return nil, re.ErrorCodePluginInitFailure.NewError(re.KeyManagementProvider, ProviderName, re.AKVLink, err, "failed to create keyvault client", re.HideStackTrace)
 	}
@@ -293,7 +293,7 @@ func parseAzureEnvironment(cloudName string) (*azure.Environment, error) {
 	return &env, err
 }
 
-func initializeKvClient(ctx context.Context, keyVaultEndpoint, tenantID, clientID string) (*azkeys.Client, *azsecrets.Client, error) {
+func initializeKvClient(keyVaultEndpoint, tenantID, clientID string) (*azkeys.Client, *azsecrets.Client, error) {
 
 	// Trim any trailing slash from the endpoint
 	kvEndpoint := strings.TrimSuffix(keyVaultEndpoint, "/")

--- a/pkg/keymanagementprovider/azurekeyvault/provider_test.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider_test.go
@@ -817,3 +817,46 @@ func TestInitializeKvClient(t *testing.T) {
 		})
 	}
 }
+
+// Test cases for keyType switch case handling
+func TestGetKeyFromKeyBundlex(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyType  azkeys.JSONWebKeyType
+		expected azkeys.JSONWebKeyType
+		curve    azkeys.JSONWebKeyCurveName
+		x        []byte
+		y        []byte
+		n        []byte
+		e        []byte
+	}{
+		{
+			name:     "Test ECHSM to EC",
+			keyType:  azkeys.JSONWebKeyTypeECHSM,
+			expected: azkeys.JSONWebKeyTypeEC,
+			curve:    azkeys.JSONWebKeyCurveNameP256,                                                                                                                                                                         // Example curve name
+			x:        []byte{0x6b, 0x17, 0xd1, 0xf2, 0xe1, 0x2c, 0x42, 0x47, 0xf8, 0xbc, 0xe6, 0xe5, 0x63, 0xa4, 0x40, 0xf2, 0x77, 0x03, 0x7d, 0x81, 0x2d, 0xeb, 0x33, 0xa0, 0xf4, 0xa1, 0x39, 0x45, 0xd8, 0x98, 0xc2, 0x96}, // Valid x-coordinate for P-256
+			y:        []byte{0x4f, 0xe3, 0x42, 0xe2, 0xfe, 0x1a, 0x7f, 0x9b, 0x8e, 0xe7, 0xeb, 0x4a, 0x7c, 0x0f, 0x9e, 0x16, 0x2b, 0xce, 0x33, 0x57, 0x6b, 0x31, 0x5e, 0xce, 0xcb, 0xb6, 0x40, 0x68, 0x37, 0xbf, 0x51, 0xf5}, // Valid y-coordinate for P-256
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webKey := &azkeys.JSONWebKey{
+				Kty: &tt.keyType,
+			}
+			if tt.keyType == azkeys.JSONWebKeyTypeECHSM {
+				webKey.Crv = &tt.curve
+				webKey.X = tt.x
+				webKey.Y = tt.y
+			}
+			keyBundle := azkeys.KeyBundle{
+				Key: webKey,
+			}
+
+			_, err := getKeyFromKeyBundle(keyBundle)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, *webKey.Kty)
+		})
+	}
+}

--- a/pkg/keymanagementprovider/azurekeyvault/provider_test.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider_test.go
@@ -68,7 +68,7 @@ func SkipTestInitializeKVClient(t *testing.T) {
 	}
 
 	for i := range testEnvs {
-		kvClientkeys, kvClientSecrets, err := initializeKvClient(context.TODO(), testEnvs[i].KeyVaultEndpoint, "", "")
+		kvClientkeys, kvClientSecrets, err := initializeKvClient(testEnvs[i].KeyVaultEndpoint, "", "")
 		assert.NoError(t, err)
 		assert.NotNil(t, kvClientkeys)
 		assert.NotNil(t, kvClientSecrets)
@@ -180,7 +180,7 @@ func TestCreate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			initKVClient = func(_ context.Context, _, _, _ string) (*azkeys.Client, *azsecrets.Client, error) {
+			initKVClient = func(_, _, _ string) (*azkeys.Client, *azsecrets.Client, error) {
 				return &azkeys.Client{}, &azsecrets.Client{}, nil
 			}
 			_, err := factory.Create("v1", tc.config, "")
@@ -736,7 +736,7 @@ func TestInitializeKvClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := initializeKvClient(context.Background(), tt.kvEndpoint, tt.tenantID, tt.clientID)
+			_, _, err := initializeKvClient(tt.kvEndpoint, tt.tenantID, tt.clientID)
 			if tt.expectedErr != (err != nil) {
 				t.Fatalf("expected error: %v, got: %v", tt.expectedErr, err)
 			}

--- a/pkg/keymanagementprovider/azurekeyvault/provider_test.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider_test.go
@@ -74,8 +74,6 @@ func SkipTestInitializeKVClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, kvClientkeys)
 		assert.NotNil(t, kvClientSecrets)
-		// assert.NotNil(t, kvClientkeys.Authorizer)
-		// assert.Contains(t, kvClientkeys.UserAgent, version.UserAgent)
 	}
 }
 
@@ -916,6 +914,5 @@ func TestInitializeKvClient_FailureInAzSecretsClient(t *testing.T) {
 	assert.Nil(t, kvClientKeys)
 	assert.Nil(t, kvClientSecrets)
 	assert.Error(t, err)
-	// assert.Contains(t, err.Error(), "Failed to create Key Vault client")
 	assert.Contains(t, err.Error(), "failed to create workload identity credential")
 }

--- a/pkg/keymanagementprovider/azurekeyvault/provider_test.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto"
 	"encoding/base64"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -38,28 +37,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
-
-// TestParseAzureEnvironment tests the parseAzureEnvironment function
-func TestParseAzureEnvironment(t *testing.T) {
-	envNamesArray := []string{"AZURECHINACLOUD", "AZUREGERMANCLOUD", "AZUREPUBLICCLOUD", "AZUREUSGOVERNMENTCLOUD", ""}
-	for _, envName := range envNamesArray {
-		azureEnv, err := parseAzureEnvironment(envName)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-		if strings.EqualFold(envName, "") && !strings.EqualFold(azureEnv.Name, "AZUREPUBLICCLOUD") {
-			t.Fatalf("string doesn't match, expected AZUREPUBLICCLOUD, got %s", azureEnv.Name)
-		} else if !strings.EqualFold(envName, "") && !strings.EqualFold(envName, azureEnv.Name) {
-			t.Fatalf("string doesn't match, expected %s, got %s", envName, azureEnv.Name)
-		}
-	}
-
-	wrongEnvName := "AZUREWRONGCLOUD"
-	_, err := parseAzureEnvironment(wrongEnvName)
-	if err == nil {
-		t.Fatalf("expected error for wrong azure environment name")
-	}
-}
 
 func SkipTestInitializeKVClient(t *testing.T) {
 	testEnvs := []azure.Environment{

--- a/pkg/keymanagementprovider/azurekeyvault/provider_test.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider_test.go
@@ -82,15 +82,6 @@ func TestCreate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "invalid cloud name",
-			config: config.KeyManagementProviderConfig{
-				"vaultUri":  "https://testkv.vault.azure.net/",
-				"tenantID":  "tid",
-				"cloudName": "AzureCloud",
-			},
-			expectErr: true,
-		},
-		{
 			name: "certificates & keys array not set",
 			config: config.KeyManagementProviderConfig{
 				"vaultUri":             "https://testkv.vault.azure.net/",

--- a/pkg/keymanagementprovider/azurekeyvault/provider_test.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider_test.go
@@ -68,7 +68,7 @@ func SkipTestInitializeKVClient(t *testing.T) {
 	}
 
 	for i := range testEnvs {
-		kvClientkeys, kvClientSecrets, err := initializeKvClient(testEnvs[i].KeyVaultEndpoint, "", "")
+		kvClientkeys, kvClientSecrets, err := initializeKvClient(context.TODO(), testEnvs[i].KeyVaultEndpoint, "", "")
 		assert.NoError(t, err)
 		assert.NotNil(t, kvClientkeys)
 		assert.NotNil(t, kvClientSecrets)
@@ -180,7 +180,7 @@ func TestCreate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			initKVClient = func(_, _, _ string) (*azkeys.Client, *azsecrets.Client, error) {
+			initKVClient = func(_ context.Context, _, _, _ string) (*azkeys.Client, *azsecrets.Client, error) {
 				return &azkeys.Client{}, &azsecrets.Client{}, nil
 			}
 			_, err := factory.Create("v1", tc.config, "")
@@ -736,7 +736,7 @@ func TestInitializeKvClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := initializeKvClient(tt.kvEndpoint, tt.tenantID, tt.clientID)
+			_, _, err := initializeKvClient(context.Background(), tt.kvEndpoint, tt.tenantID, tt.clientID)
 			if tt.expectedErr != (err != nil) {
 				t.Fatalf("expected error: %v, got: %v", tt.expectedErr, err)
 			}

--- a/pkg/keymanagementprovider/azurekeyvault/provider_test.go
+++ b/pkg/keymanagementprovider/azurekeyvault/provider_test.go
@@ -20,18 +20,16 @@ package azurekeyvault
 import (
 	"context"
 	"crypto"
-	"encoding/base64"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azcertificates"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/ratify-project/ratify/pkg/keymanagementprovider/azurekeyvault/types"
 	"github.com/ratify-project/ratify/pkg/keymanagementprovider/config"
 	"github.com/stretchr/testify/assert"
@@ -47,10 +45,11 @@ func SkipTestInitializeKVClient(t *testing.T) {
 	}
 
 	for i := range testEnvs {
-		kvClientkeys, kvClientSecrets, err := initializeKvClient(context.TODO(), testEnvs[i].KeyVaultEndpoint, "", "", nil)
+		keyKVClient, secretKVClient, certificateKVClient, err := initializeKvClient(testEnvs[i].KeyVaultEndpoint, "", "", nil)
 		assert.NoError(t, err)
-		assert.NotNil(t, kvClientkeys)
-		assert.NotNil(t, kvClientSecrets)
+		assert.NotNil(t, keyKVClient)
+		assert.NotNil(t, secretKVClient)
+		assert.NotNil(t, certificateKVClient)
 	}
 }
 
@@ -157,8 +156,8 @@ func TestCreate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			initKVClient = func(_ context.Context, _, _, _ string, _ azcore.TokenCredential) (*azkeys.Client, *azsecrets.Client, error) {
-				return &azkeys.Client{}, &azsecrets.Client{}, nil
+			initKVClient = func(_, _, _ string, _ azcore.TokenCredential) (*azkeys.Client, *azsecrets.Client, *azcertificates.Client, error) {
+				return &azkeys.Client{}, &azsecrets.Client{}, &azcertificates.Client{}, nil
 			}
 			_, err := factory.Create("v1", tc.config, "")
 			if tc.expectErr != (err != nil) {
@@ -168,239 +167,58 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-type MockKvClient struct {
-	GetCertificateFunc func(ctx context.Context, certificateName string, certificateVersion string, arg string) (kv.CertificateBundle, error)
-	GetSecretFunc      func(ctx context.Context, secretName string, secretVersion string, arg string) (kv.SecretBundle, error)
-	GetKeyFunc         func(ctx context.Context, keyName string, keyVersion string, arg string) (kv.KeyBundle, error)
-}
-
-func (m *MockKvClient) GetCertificate(ctx context.Context, certificateName string, certificateVersion string, arg string) (kv.CertificateBundle, error) {
-	if m.GetCertificateFunc != nil {
-		return m.GetCertificateFunc(ctx, certificateName, certificateVersion, arg)
-	}
-	return kv.CertificateBundle{}, nil
-}
-func (m *MockKvClient) GetSecret(ctx context.Context, secretName string, secretVersion string, arg string) (kv.SecretBundle, error) {
-	if m.GetSecretFunc != nil {
-		return m.GetSecretFunc(ctx, secretName, secretVersion, arg)
-	}
-	return kv.SecretBundle{}, nil
-}
-func (m *MockKvClient) GetKey(ctx context.Context, keyName string, keyVersion string, arg string) (kv.KeyBundle, error) {
-	if m.GetKeyFunc != nil {
-		return m.GetKeyFunc(ctx, keyName, keyVersion, arg)
-	}
-	return kv.KeyBundle{}, nil
-}
-
 // TestGetCertificates tests the GetCertificates function
 func TestGetCertificates(t *testing.T) {
-	testCases := []struct {
-		name         string
-		mockKvClient *MockKvClient
-		expectedErr  bool
-	}{
-		{
-			name: "GetSecret error",
-			mockKvClient: &MockKvClient{
-				GetSecretFunc: func(_ context.Context, _ string, _ string, _ string) (kv.SecretBundle, error) {
-					return kv.SecretBundle{}, errors.New("error")
-				},
+	factory := &akvKMProviderFactory{}
+	config := config.KeyManagementProviderConfig{
+		"vaultUri": "https://testkv.vault.azure.net/",
+		"tenantID": "tid",
+		"clientID": "clientid",
+		"certificates": []map[string]interface{}{
+			{
+				"name":    "cert1",
+				"version": "",
 			},
-			expectedErr: true,
-		},
-		{
-			name: "Certificate disabled",
-			mockKvClient: &MockKvClient{
-				GetCertificateFunc: func(_ context.Context, _ string, _ string, _ string) (kv.CertificateBundle, error) {
-					return kv.CertificateBundle{
-						ID:  to.StringPtr("https://testkv.vault.azure.net/certificates/cert1"),
-						Kid: to.StringPtr("https://testkv.vault.azure.net/keys/key1"),
-						Attributes: &kv.CertificateAttributes{
-							Enabled: to.BoolPtr(false),
-						},
-					}, nil
-				},
-				GetSecretFunc: func(_ context.Context, _ string, _ string, _ string) (kv.SecretBundle, error) {
-					err := autorest.DetailedError{
-						Original: &azure.RequestError{
-							ServiceError: &azure.ServiceError{Code: "SecretDisabled"},
-						},
-					}
-					return kv.SecretBundle{}, err
-				},
-			},
-			expectedErr: false,
-		},
-		{
-			name: "Certificate disabled error",
-			mockKvClient: &MockKvClient{
-				GetCertificateFunc: func(_ context.Context, _ string, _ string, _ string) (kv.CertificateBundle, error) {
-					return kv.CertificateBundle{}, errors.New("error")
-				},
-				GetSecretFunc: func(_ context.Context, _ string, _ string, _ string) (kv.SecretBundle, error) {
-					err := autorest.DetailedError{
-						Original: &azure.RequestError{
-							ServiceError: &azure.ServiceError{Code: "SecretDisabled"},
-						},
-					}
-					return kv.SecretBundle{}, err
-				},
-			},
-			expectedErr: true,
-		},
-		{
-			name: "Certificate enabled",
-			mockKvClient: &MockKvClient{
-				GetCertificateFunc: func(_ context.Context, _ string, _ string, _ string) (kv.CertificateBundle, error) {
-					return kv.CertificateBundle{
-						ID:  to.StringPtr("https://testkv.vault.azure.net/certificates/cert1"),
-						Kid: to.StringPtr("https://testkv.vault.azure.net/keys/key1"),
-						Attributes: &kv.CertificateAttributes{
-							Enabled: to.BoolPtr(true),
-						},
-					}, nil
-				},
-				GetSecretFunc: func(_ context.Context, _ string, _ string, _ string) (kv.SecretBundle, error) {
-					return kv.SecretBundle{
-						ID:          to.StringPtr("https://testkv.vault.azure.net/secrets/secret1"),
-						Kid:         to.StringPtr("https://testkv.vault.azure.net/keys/key1"),
-						ContentType: to.StringPtr("application/x-pem-file"),
-						Attributes: &kv.SecretAttributes{
-							Enabled: to.BoolPtr(true),
-						},
-						Value: to.StringPtr("-----BEGIN CERTIFICATE-----\nMIIC8TCCAdmgAwIBAgIUaNrwbhs/I1ecqUYdzD2xuAVNdmowDQYJKoZIhvcNAQEL\nBQAwKjEPMA0GA1UECgwGUmF0aWZ5MRcwFQYDVQQDDA5SYXRpZnkgUm9vdCBDQTAe\nFw0yMzA2MjEwMTIyMzdaFw0yNDA2MjAwMTIyMzdaMBkxFzAVBgNVBAMMDnJhdGlm\neS5kZWZhdWx0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtskG1BUt\n4Fw2lbm53KbwZb1hnLmWdwRotZyznhhk/yrUDcq3uF6klwpk/E2IKfUKIo6doHSk\nXaEZXR68UtXygvA4wdg7xZ6kKpXy0gu+RxGE6CGtDHTyDDzITu+NBjo21ZSsyGpQ\nJeIKftUCHdwdygKf0CdJx8A29GBRpHGCmJadmt7tTzOnYjmbuPVLeqJo/Ex9qXcG\nZbxoxnxr5NCocFeKx+EbLo+k/KjdFB2PKnhgzxAaMMMP6eXPr8l5AlzkC83EmPvN\ntveuaBbamdlFkD+53TZeZlxt3GIdq93Iw/UpbQ/pvhbrztMT+UVEkm15sShfX8Xn\nL2st5A4n0V+66QIDAQABoyAwHjAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIH\ngDANBgkqhkiG9w0BAQsFAAOCAQEAGpOqozyfDSBjoTepsRroxxcZ4sq65gw45Bme\nm36BS6FG0WHIg3cMy6KIIBefTDSKrPkKNTtuF25AeGn9jM+26cnfDM78ZH0+Lnn7\n7hs0MA64WMPQaWs9/+89aM9NADV9vp2zdG4xMi6B7DruvKWyhJaNoRqK/qP6LdSQ\nw8M+21sAHvXgrRkQtJlVOzVhgwt36NOb1hzRlQiZB+nhv2Wbw7fbtAaADk3JAumf\nvM+YdPS1KfAFaYefm4yFd+9/C0KOkHico3LTbELO5hG0Mo/EYvtjM+Fljb42EweF\n3nAx1GSPe5Tn8p3h6RyJW5HIKozEKyfDuLS0ccB/nqT3oNjcTw==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIDRTCCAi2gAwIBAgIUcC33VfaMhOnsl7avNTRVQozoVtUwDQYJKoZIhvcNAQEL\nBQAwKjEPMA0GA1UECgwGUmF0aWZ5MRcwFQYDVQQDDA5SYXRpZnkgUm9vdCBDQTAe\nFw0yMzA2MjEwMTIyMzZaFw0yMzA2MjIwMTIyMzZaMCoxDzANBgNVBAoMBlJhdGlm\neTEXMBUGA1UEAwwOUmF0aWZ5IFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IB\nDwAwggEKAoIBAQDDFhDnyPrVDZaeRu6Tbg1a/iTwus+IuX+h8aKhKS1yHz4EF/Lz\nxCy7lNSQ9srGMMVumWuNom/ydIphff6PejZM1jFKPU6OQR/0JX5epcVIjbKa562T\nDguUxJ+h5V3EIyM4RqOWQ2g/xZo86x5TzyNJXiVdHHRvmDvUNwPpMeDjr/EHVAni\n5YQObxkJRiiZ7XOa5zz3YztVm8sSZAwPWroY1HIfvtP+KHpiNDIKSymmuJkH4SEr\nJn++iqN8na18a9DFBPTTrLPe3CxATGrMfosCMZ6LP3iFLLc/FaSpwcnugWdewsUK\nYs+sUY7jFWR7x7/1nyFWyRrQviM4f4TY+K7NAgMBAAGjYzBhMB0GA1UdDgQWBBQH\nYePW7QPP2p1utr3r6gqzEkKs+DAfBgNVHSMEGDAWgBQHYePW7QPP2p1utr3r6gqz\nEkKs+DAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwICBDANBgkqhkiG9w0B\nAQsFAAOCAQEAjKp4vx3bFaKVhAbQeTsDjWJgmXLK2vLgt74MiUwSF6t0wehlfszE\nIcJagGJsvs5wKFf91bnwiqwPjmpse/thPNBAxh1uEoh81tOklv0BN790vsVpq3t+\ncnUvWPiCZdRlAiGGFtRmKk3Keq4sM6UdiUki9s+wnxypHVb4wIpVxu5R271Lnp5I\n+rb2EQ48iblt4XZPczf/5QJdTgbItjBNbuO8WVPOqUIhCiFuAQziLtNUq3p81dHO\nQ2BPgmaitCpIUYHVYighLauBGCH8xOFzj4a4KbOxKdxyJTd0La/vRCKaUtJX67Lc\nfQYVR9HXQZ0YlmwPcmIG5v7wBfcW34NUvA==\n-----END CERTIFICATE-----\n"),
-					}, nil
-				},
-			},
-		},
-		{
-			name: "getCertsFromSecretBundle error",
-			mockKvClient: &MockKvClient{
-				GetSecretFunc: func(_ context.Context, _ string, _ string, _ string) (kv.SecretBundle, error) {
-					return kv.SecretBundle{
-						ContentType: to.StringPtr("test"),
-						ID:          to.StringPtr("https://testkv.vault.azure.net/secrets/secret1"),
-						Kid:         to.StringPtr("https://testkv.vault.azure.net/keys/key1"),
-						Attributes: &kv.SecretAttributes{
-							Enabled: to.BoolPtr(true),
-						},
-						Value: to.StringPtr("-----BEGIN CERTIFICATE-----\nMIIC8TCCAdmgAwIBAgIUaNrwbhs/I1ecqUYdzD2xuAVNdmowDQYJKoZIhvcNAQEL\nBQAwKjEPMA0GA1UECgwGUmF0aWZ5MRcwFQYDVQQDDA5SYXRpZnkgUm9vdCBDQTAe\nFw0yMzA2MjEwMTIyMzdaFw0yNDA2MjAwMTIyMzdaMBkxFzAVBgNVBAMMDnJhdGlm\neS5kZWZhdWx0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtskG1BUt\n4Fw2lbm53KbwZb1hnLmWdwRotZyznhhk/yrUDcq3uF6klwpk/E2IKfUKIo6doHSk\nXaEZXR68UtXygvA4wdg7xZ6kKpXy0gu+RxGE6CGtDHTyDDzITu+NBjo21ZSsyGpQ\nJeIKftUCHdwdygKf0CdJx8A29GBRpHGCmJadmt7tTzOnYjmbuPVLeqJo/Ex9qXcG\nZbxoxnxr5NCocFeKx+EbLo+k/KjdFB2PKnhgzxAaMMMP6eXPr8l5AlzkC83EmPvN\ntveuaBbamdlFkD+53TZeZlxt3GIdq93Iw/UpbQ/pvhbrztMT+UVEkm15sShfX8Xn\nL2st5A4n0V+66QIDAQABoyAwHjAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIH\ngDANBgkqhkiG9w0BAQsFAAOCAQEAGpOqozyfDSBjoTepsRroxxcZ4sq65gw45Bme\nm36BS6FG0WHIg3cMy6KIIBefTDSKrPkKNTtuF25AeGn9jM+26cnfDM78ZH0+Lnn7\n7hs0MA64WMPQaWs9/+89aM9NADV9vp2zdG4xMi6B7DruvKWyhJaNoRqK/qP6LdSQ\nw8M+21sAHvXgrRkQtJlVOzVhgwt36NOb1hzRlQiZB+nhv2Wbw7fbtAaADk3JAumf\nvM+YdPS1KfAFaYefm4yFd+9/C0KOkHico3LTbELO5hG0Mo/EYvtjM+Fljb42EweF\n3nAx1GSPe5Tn8p3h6RyJW5HIKozEKyfDuLS0ccB/nqT3oNjcTw==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIDRTCCAi2gAwIBAgIUcC33VfaMhOnsl7avNTRVQozoVtUwDQYJKoZIhvcNAQEL\nBQAwKjEPMA0GA1UECgwGUmF0aWZ5MRcwFQYDVQQDDA5SYXRpZnkgUm9vdCBDQTAe\nFw0yMzA2MjEwMTIyMzZaFw0yMzA2MjIwMTIyMzZaMCoxDzANBgNVBAoMBlJhdGlm\neTEXMBUGA1UEAwwOUmF0aWZ5IFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IB\nDwAwggEKAoIBAQDDFhDnyPrVDZaeRu6Tbg1a/iTwus+IuX+h8aKhKS1yHz4EF/Lz\nxCy7lNSQ9srGMMVumWuNom/ydIphff6PejZM1jFKPU6OQR/0JX5epcVIjbKa562T\nDguUxJ+h5V3EIyM4RqOWQ2g/xZo86x5TzyNJXiVdHHRvmDvUNwPpMeDjr/EHVAni\n5YQObxkJRiiZ7XOa5zz3YztVm8sSZAwPWroY1HIfvtP+KHpiNDIKSymmuJkH4SEr\nJn++iqN8na18a9DFBPTTrLPe3CxATGrMfosCMZ6LP3iFLLc/FaSpwcnugWdewsUK\nYs+sUY7jFWR7x7/1nyFWyRrQviM4f4TY+K7NAgMBAAGjYzBhMB0GA1UdDgQWBBQH\nYePW7QPP2p1utr3r6gqzEkKs+DAfBgNVHSMEGDAWgBQHYePW7QPP2p1utr3r6gqz\nEkKs+DAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwICBDANBgkqhkiG9w0B\nAQsFAAOCAQEAjKp4vx3bFaKVhAbQeTsDjWJgmXLK2vLgt74MiUwSF6t0wehlfszE\nIcJagGJsvs5wKFf91bnwiqwPjmpse/thPNBAxh1uEoh81tOklv0BN790vsVpq3t+\ncnUvWPiCZdRlAiGGFtRmKk3Keq4sM6UdiUki9s+wnxypHVb4wIpVxu5R271Lnp5I\n+rb2EQ48iblt4XZPczf/5QJdTgbItjBNbuO8WVPOqUIhCiFuAQziLtNUq3p81dHO\nQ2BPgmaitCpIUYHVYighLauBGCH8xOFzj4a4KbOxKdxyJTd0La/vRCKaUtJX67Lc\nfQYVR9HXQZ0YlmwPcmIG5v7wBfcW34NUvA==\n-----END CERTIFICATE-----\n"),
-					}, nil
-				},
-			},
-			expectedErr: true,
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			provider := &akvKMProvider{
-				certificates: []types.KeyVaultValue{
-					{
-						Name:    "cert1",
-						Version: "c1f03df1113d460491d970737dfdc35d",
-					},
-				},
-				kvClient: tc.mockKvClient,
-			}
-
-			_, _, err := provider.GetCertificates(context.Background())
-			if tc.expectedErr != (err != nil) {
-				t.Fatalf("error = %v, expectedErr = %v", err, tc.expectedErr)
-			}
-		})
+	provider, err := factory.Create("v1", config, "")
+	if err != nil {
+		t.Fatalf("expected no err but got error = %v", err)
 	}
+
+	certs, certStatus, err := provider.GetCertificates(context.Background())
+	assert.NotNil(t, err)
+	assert.Nil(t, certs)
+	assert.Nil(t, certStatus)
 }
 
 // TestGetKeys tests the GetKeys function
 func TestGetKeys(t *testing.T) {
-	testCases := []struct {
-		name         string
-		mockKvClient *MockKvClient
-		expectedErr  bool
-	}{
-		{
-			name: "GetKey error",
-			mockKvClient: &MockKvClient{
-				GetKeyFunc: func(_ context.Context, _ string, _ string, _ string) (kv.KeyBundle, error) {
-					return kv.KeyBundle{}, errors.New("error")
-				},
+	factory := &akvKMProviderFactory{}
+	config := config.KeyManagementProviderConfig{
+		"vaultUri": "https://testkv.vault.azure.net/",
+		"tenantID": "tid",
+		"clientID": "clientid",
+		"keys": []map[string]interface{}{
+			{
+				"name": "key1",
 			},
-			expectedErr: true,
-		},
-		{
-			name: "Key disabled",
-			mockKvClient: &MockKvClient{
-				GetKeyFunc: func(_ context.Context, _ string, _ string, _ string) (kv.KeyBundle, error) {
-					return kv.KeyBundle{
-						Key: &kv.JSONWebKey{
-							Kid: to.StringPtr("https://testkv.vault.azure.net/keys/key1"),
-						},
-						Attributes: &kv.KeyAttributes{
-							Enabled: to.BoolPtr(false),
-						},
-					}, nil
-				},
-			},
-			expectedErr: false,
-		},
-		{
-			name: "getKeyFromKeyBundle error",
-			mockKvClient: &MockKvClient{
-				GetKeyFunc: func(_ context.Context, _ string, _ string, _ string) (kv.KeyBundle, error) {
-					return kv.KeyBundle{
-						Key: &kv.JSONWebKey{
-							Kid: to.StringPtr("https://testkv.vault.azure.net/keys/key1"),
-						},
-						Attributes: &kv.KeyAttributes{
-							Enabled: to.BoolPtr(true),
-						},
-					}, nil
-				},
-			},
-			expectedErr: true,
-		},
-		{
-			name: "Key enabled",
-			mockKvClient: &MockKvClient{
-				GetKeyFunc: func(_ context.Context, _ string, _ string, _ string) (kv.KeyBundle, error) {
-					return kv.KeyBundle{
-						Key: &kv.JSONWebKey{
-							Kid: to.StringPtr("https://testkv.vault.azure.net/keys/key1"),
-							Kty: kv.RSA,
-							N:   to.StringPtr(base64.StdEncoding.EncodeToString([]byte("n"))),
-							E:   to.StringPtr(base64.StdEncoding.EncodeToString([]byte("e"))),
-						},
-						Attributes: &kv.KeyAttributes{
-							Enabled: to.BoolPtr(true),
-						},
-					}, nil
-				},
-			},
-			expectedErr: false,
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			provider := &akvKMProvider{
-				keys: []types.KeyVaultValue{
-					{
-						Name:    "key1",
-						Version: "c1f03df1113d460491d970737dfdc35d",
-					},
-				},
-				kvClientKeys:     tc.mockKvClient,
-				kvClientSecretss: tc.mockKvClient,
-			}
-
-			_, _, err := provider.GetKeys(context.Background())
-			if tc.expectedErr != (err != nil) {
-				t.Fatalf("error = %v, expectedErr = %v", err, tc.expectedErr)
-			}
-		})
+	initKVClient = func(_, _, _ string, _ azcore.TokenCredential) (*azkeys.Client, *azsecrets.Client, *azcertificates.Client, error) {
+		return &azkeys.Client{}, &azsecrets.Client{}, &azcertificates.Client{}, nil
 	}
+	provider, err := factory.Create("v1", config, "")
+	if err != nil {
+		t.Fatalf("expected no err but got error = %v", err)
+	}
+
+	keys, keyStatus, err := provider.GetKeys(context.Background())
+	assert.NotNil(t, err)
+	assert.Nil(t, keys)
+	assert.Nil(t, keyStatus)
 }
 
 func TestIsRefreshable(t *testing.T) {
@@ -695,6 +513,10 @@ type MockAzSecretsClient struct {
 	mock.Mock
 }
 
+type MockAzCertificatesClient struct {
+	mock.Mock
+}
+
 type MockWorkloadIdentityCredential struct {
 	mock.Mock
 }
@@ -715,10 +537,16 @@ func (m *MockAzSecretsClient) NewClient(endpoint string, credential *azidentity.
 	return args.Get(0).(*azsecrets.Client), args.Error(1)
 }
 
+func (m *MockAzCertificatesClient) NewClient(endpoint string, credential *azidentity.WorkloadIdentityCredential, options *azcertificates.ClientOptions) (*azcertificates.Client, error) {
+	args := m.Called(endpoint, credential, options)
+	return args.Get(0).(*azcertificates.Client), args.Error(1)
+}
+
 func TestInitializeKvClient(t *testing.T) {
 	mockCredential := new(MockWorkloadIdentityCredential)
 	mockKeysClient := new(MockAzKeysClient)
 	mockSecretsClient := new(MockAzSecretsClient)
+	mockCertificatesClient := new(MockAzCertificatesClient)
 
 	tests := []struct {
 		name              string
@@ -776,19 +604,22 @@ func TestInitializeKvClient(t *testing.T) {
 			mockCredential.On("NewWorkloadIdentityCredential", mock.Anything).Return(mockCredential, tt.mockCredentialErr)
 			mockKeysClient.On("NewClient", tt.kvEndpoint, mockCredential, mock.Anything).Return(mockKeysClient, tt.mockKeysErr)
 			mockSecretsClient.On("NewClient", tt.kvEndpoint, mockCredential, mock.Anything).Return(mockSecretsClient, tt.mockSecretsErr)
+			mockCertificatesClient.On("NewClient", tt.kvEndpoint, mockCredential, mock.Anything).Return(mockCertificatesClient, tt.mockSecretsErr)
 
 			// Call function under test
-			keysClient, secretsClient, err := initializeKvClient(context.Background(), tt.kvEndpoint, tt.tenantID, tt.clientID, nil)
+			keysKVClient, secretsKVClient, certificatesKVClient, err := initializeKvClient(tt.kvEndpoint, tt.tenantID, tt.clientID, nil)
 
 			// Validate expectations
 			if tt.expectedErr {
 				assert.Error(t, err)
-				assert.Nil(t, keysClient)
-				assert.Nil(t, secretsClient)
+				assert.Nil(t, keysKVClient)
+				assert.Nil(t, secretsKVClient)
+				assert.Nil(t, certificatesKVClient)
 			} else {
 				assert.NoError(t, err)
-				assert.NotNil(t, keysClient)
-				assert.NotNil(t, secretsClient)
+				assert.NotNil(t, keysKVClient)
+				assert.NotNil(t, secretsKVClient)
+				assert.Nil(t, certificatesKVClient)
 			}
 		})
 	}
@@ -839,7 +670,6 @@ func TestGetKeyFromKeyBundlex(t *testing.T) {
 
 func TestInitializeKvClient_Success(t *testing.T) {
 	// Mock the context and input parameters
-	ctx := context.Background()
 	keyVaultEndpoint := "https://myvault.vault.azure.net/"
 	tenantID := "tenant-id"
 	clientID := "client-id"
@@ -851,45 +681,64 @@ func TestInitializeKvClient_Success(t *testing.T) {
 	}
 
 	// Run the function with the mock credential
-	kvClientKeys, kvClientSecrets, err := initializeKvClient(ctx, keyVaultEndpoint, tenantID, clientID, mockCredential)
+	keysKVClient, secretsKVClient, certificatesKVClient, err := initializeKvClient(keyVaultEndpoint, tenantID, clientID, mockCredential)
 
 	// Assert the function succeeds without errors and clients are created
-	assert.NotNil(t, kvClientKeys)
-	assert.NotNil(t, kvClientSecrets)
+	assert.NotNil(t, keysKVClient)
+	assert.NotNil(t, secretsKVClient)
+	assert.NotNil(t, certificatesKVClient)
 	assert.NoError(t, err)
 }
 
 func TestInitializeKvClient_FailureInAzKeysClient(t *testing.T) {
 	// Mock the context and input parameters
-	ctx := context.Background()
 	keyVaultEndpoint := "https://invalid-vault.vault.azure.net/"
 	tenantID := "mock_tenant-id"
 	clientID := "mock_client-id"
 
 	// Run the function
-	kvClientKeys, kvClientSecrets, err := initializeKvClient(ctx, keyVaultEndpoint, tenantID, clientID, nil)
+	keysKVClient, secretsKVClient, certificatesKVClient, err := initializeKvClient(keyVaultEndpoint, tenantID, clientID, nil)
 
 	// Assert that an error occurred and clients were not created
-	assert.Nil(t, kvClientKeys)
-	assert.Nil(t, kvClientSecrets)
+	assert.Nil(t, keysKVClient)
+	assert.Nil(t, secretsKVClient)
+	assert.Nil(t, certificatesKVClient)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create workload identity credential")
 }
 
 func TestInitializeKvClient_FailureInAzSecretsClient(t *testing.T) {
 	// Mock the context and input parameters
-	ctx := context.Background()
 	keyVaultEndpoint := "https://valid-vault.vault.azure.net/"
 	tenantID := "tenant-id"
 	clientID := "client-id"
 
 	// Modify the azsecrets.NewClient function to simulate failure
 	// Run the function
-	kvClientKeys, kvClientSecrets, err := initializeKvClient(ctx, keyVaultEndpoint, tenantID, clientID, nil)
+	keysKVClient, secretsKVClient, certificatesKVClient, err := initializeKvClient(keyVaultEndpoint, tenantID, clientID, nil)
 
 	// Assert that an error occurred and clients were not created
-	assert.Nil(t, kvClientKeys)
-	assert.Nil(t, kvClientSecrets)
+	assert.Nil(t, keysKVClient)
+	assert.Nil(t, secretsKVClient)
+	assert.Nil(t, certificatesKVClient)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create workload identity credential")
+}
+
+func TestInitializeKvClient_FailureInAzCertificatesClient(t *testing.T) {
+	// Mock the context and input parameters
+	keyVaultEndpoint := "https://valid-vault.vault.azure.net/"
+	tenantID := "tenant-id"
+	clientID := "client-id"
+
+	// Modify the azsecrets.NewClient function to simulate failure
+	// Run the function
+	keysKVClient, secretsKVClient, certificatesKVClient, err := initializeKvClient(keyVaultEndpoint, tenantID, clientID, nil)
+
+	// Assert that an error occurred and clients were not created
+	assert.Nil(t, keysKVClient)
+	assert.Nil(t, secretsKVClient)
+	assert.Nil(t, certificatesKVClient)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create workload identity credential")
 }

--- a/pkg/keymanagementprovider/azurekeyvault/types/types.go
+++ b/pkg/keymanagementprovider/azurekeyvault/types/types.go
@@ -26,7 +26,7 @@ const (
 	// Certificate version string for the certificate status property
 	StatusVersion = "Version"
 	// Enabled string for the certificate status property
-	StatusEnabled = "True"
+	StatusEnabled = "Enabled"
 	// Last refreshed string for the certificate status property
 	StatusLastRefreshed = "LastRefreshed"
 )


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Azure authentication currently uses go-autorest SDK. It's now deprecated and using MSAL and azidentity SDKs are now recommended. This PR replaces the deprecated SDK with azidentity.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1630 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[This tutorial](https://ratify.dev/docs/next/quickstarts/ratify-on-azure/#set-up-an-azure-workload-identity) was followed to test authenticating AKS with AKV and retrieval of certificates. 
1- **KeyManagementProvider scenario**: After deploying the following kmp resource using `kubectl apply -f kmp_config.yaml`, the Ratify pod log shows successful retrieval of the certificate.

kmp_config.yaml:
```
apiVersion: config.ratify.deislabs.io/v1beta1
kind: KeyManagementProvider
metadata:
  name: keymanagementprovider-akv
spec:
  type: azurekeyvault
  parameters:
    vaultURI: https://skal21kv.vault.azure.net/
    keys:
      - name: cosign
        version: 16c798cd4be049908bdcd841d20c19cd
    certificates:
      - name: wabbit-networks-io
        version: 3d6a30dfb52645ebb307d99e900c10ad
    tenantID: 72f988bf-86f1-41af-91ab-2d7cd011db47
    clientID: 6f77181a-6ca6-404d-accc-703b3ae18d03

```

Ratify logs:
```
time=2024-11-05T04:27:27.618019657Z level=info msg=provider.cloudEnv.KeyVaultEndpoint https://vault.azure.net/, provider.vaultURI https://skal21kv.vault.azure.net/ component-type=keyManagementProvider go.version=go1.22.8
time=2024-11-05T04:27:27.618039936Z level=info msg=kvEndpoint https://skal21kv.vault.azure.net component-type=keyManagementProvider go.version=go1.22.8
time=2024-11-05T04:27:27.618466847Z level=info msg=azsecrets kvclient created successfully component-type=keyManagementProvider go.version=go1.22.8
time=2024-11-05T04:27:27.618525541Z level=info msg=fetching secret from key vault, certName wabbit-networks-io, certVersion %!v(MISSING) component-type=keyManagementProvider go.version=go1.22.8
time=2024-11-05T04:27:27.901644022Z level=info msg=1 certificate(s) & 1 key(s) fetched for key management provider keymanagementprovider-akv
```

It was also verified by the following command:
`kubectl describe KeyManagementProvider keymanagementprovider-akv`
```
Name:         keymanagementprovider-akv
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  config.ratify.deislabs.io/v1beta1
Kind:         KeyManagementProvider
Metadata:
  Creation Timestamp:  2024-11-05T04:27:27Z
  Generation:          1
  Resource Version:    1802478
  UID:                 889e589a-f696-4410-bd01-73bfa8a330b3
Spec:
  Parameters:
    Certificates:
      Name:     wabbit-networks-io
      Version:  3d6a30dfb52645ebb307d99e900c10ad
    Client ID:  6f77181a-6ca6-404d-accc-703b3ae18d03
    Keys:
      Name:          cosign
      Version:       16c798cd4be049908bdcd841d20c19cd
    Tenant ID:       72f988bf-86f1-41af-91ab-2d7cd011db47
    Vault URI:       https://skal21kv.vault.azure.net/
  Refresh Interval:  
  Type:              azurekeyvault
Status:
  Issuccess:        true
  Lastfetchedtime:  2024-11-05T04:27:27Z
  Properties:
    Certificates:
      Last Refreshed:  2024-11-05T04:27:27Z
      Name:            wabbit-networks-io
      Version:         3d6a30dfb52645ebb307d99e900c10ad
    Keys:
      Last Refreshed:  2024-11-05T04:27:27Z
      Name:            cosign
      Version:         16c798cd4be049908bdcd841d20c19cd
Events:                <none>
```

2- **CertificateStore scenario**: After deploying the following certificate store resource using `kubectl apply -f cs_config.yaml`, the Ratify pod log shows successful retrieval of the certificate.

cs_config.yaml:
```
apiVersion: config.ratify.deislabs.io/v1beta1
kind: CertificateStore
metadata:
  name: certstore-akv
spec:
  provider: azurekeyvault
  parameters:
    vaultURI: https://skal21kv.vault.azure.net/
    certificates: |
      array:
        - |
          certificateName: wabbit-networks-io
          certificateVersion: 3d6a30dfb52645ebb307d99e900c10ad
    tenantID: 72f988bf-86f1-41af-91ab-2d7cd011db47
    clientID: 6f77181a-6ca6-404d-accc-703b3ae18d03
```

Ratify logs:
```
time=2024-11-11T10:26:40.87690862Z level=info msg=reconciling certificate store 'gatekeeper-system/certstore-akv'
time=2024-11-11T10:26:41.589902887Z level=info msg=1 certificates fetched for certificate store gatekeeper-system/certstore-akv
```

It was also verified by the following command:
`kubectl describe CertificateStore certstore-akv`
```
Name:         certstore-akv
Namespace:    gatekeeper-system
Labels:       <none>
Annotations:  <none>
API Version:  config.ratify.deislabs.io/v1beta1
Kind:         CertificateStore
Metadata:
  Creation Timestamp:  2024-11-11T10:26:40Z
  Generation:          1
  Resource Version:    4036265
  UID:                 a9f89508-e7a0-45a4-855f-b1e7ec0ee13e
Spec:
  Parameters:
    Certificates:  array:
  - |
    certificateName: wabbit-networks-io
    certificateVersion: 3d6a30dfb52645ebb307d99e900c10ad

    Client ID:  6f77181a-6ca6-404d-accc-703b3ae18d03
    Tenant ID:  72f988bf-86f1-41af-91ab-2d7cd011db47
    Vault URI:  https://skal21kv.vault.azure.net/
  Provider:     azurekeyvault
Status:
  Issuccess:        true
  Lastfetchedtime:  2024-11-11T10:26:40Z
  Properties:
    Certificates:
      Certificate Name:  wabbit-networks-io
      Last Refreshed:    2024-11-11T10:26:41Z
      Version:           3d6a30dfb52645ebb307d99e900c10ad
Events:                  <none>
```


# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
