### PR TITLE
chore: bump up golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,5 +26,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
-          version: v1.59.1
+          version: v1.62.2
           args: --timeout=10m

--- a/cmd/ratify/cmd/serve.go
+++ b/cmd/ratify/cmd/serve.go
@@ -118,7 +118,7 @@ func serve(opts serveCmdOptions) error {
 		if err != nil {
 			return err
 		}
-		logrus.Infof("starting server at" + opts.httpServerAddress)
+		logrus.Infof("starting server at %s", opts.httpServerAddress)
 		if err := server.Run(nil); err != nil {
 			return err
 		}

--- a/pkg/certificateprovider/certificate_provider_test.go
+++ b/pkg/certificateprovider/certificate_provider_test.go
@@ -78,7 +78,7 @@ func TestDecodeCertificates_ByteArrayToCertificates(t *testing.T) {
 
 	r, err := DecodeCertificates(c1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	expectedLen := 1

--- a/pkg/controllers/logging.go
+++ b/pkg/controllers/logging.go
@@ -122,7 +122,7 @@ func (sink *LogrusSink) createEntry(keysAndValues ...interface{}) *logrus.Entry 
 }
 
 func (sink *LogrusSink) formatMessage(msg string) string {
-	if sink.names == nil || len(sink.names) == 0 {
+	if len(sink.names) == 0 {
 		return msg
 	}
 

--- a/pkg/keymanagementprovider/keymanagementprovider_test.go
+++ b/pkg/keymanagementprovider/keymanagementprovider_test.go
@@ -85,7 +85,7 @@ func TestDecodeCertificates_ByteArrayToCertificates(t *testing.T) {
 
 	r, err := DecodeCertificates(c1)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	expectedLen := 1

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -105,7 +105,7 @@ func StartServer(httpServerAddress, configFilePath, certDirectory, caCertFile st
 		logrus.Errorf("initialize server failed with error %v, exiting..", err)
 		os.Exit(1)
 	}
-	logrus.Infof("starting server at" + httpServerAddress)
+	logrus.Infof("starting server at %s", httpServerAddress)
 	if err := server.Run(certRotatorReady); err != nil {
 		logrus.Errorf("starting server failed with error %v, exiting..", err)
 		os.Exit(1)

--- a/pkg/verifier/notation/truststore_test.go
+++ b/pkg/verifier/notation/truststore_test.go
@@ -133,7 +133,7 @@ func TestGetCertificates_ErrorFromKMPReconcile(t *testing.T) {
 	}
 	store, err := newTrustStore(nil, certStore)
 	if err != nil {
-		t.Fatalf("failed to parse verificationCertStores: " + err.Error())
+		t.Fatalf("failed to parse verificationCertStores: %s", err.Error())
 	}
 
 	controllers.NamespacedCertStores = &mockCertStores{

--- a/pkg/verifier/result_test.go
+++ b/pkg/verifier/result_test.go
@@ -16,8 +16,9 @@ limitations under the License.
 package verifier
 
 import (
-	"fmt"
 	"testing"
+
+	e "errors"
 
 	"github.com/ratify-project/ratify/errors"
 )
@@ -47,7 +48,7 @@ func TestNewVerifierResult(t *testing.T) {
 		{
 			name:                "error without detail",
 			message:             testMsg1,
-			err:                 errors.ErrorCodeUnknown.WithError(fmt.Errorf(testErrReason)).WithRemediation(testRemediation),
+			err:                 errors.ErrorCodeUnknown.WithError(e.New(testErrReason)).WithRemediation(testRemediation),
 			expectedMsg:         testMsg1,
 			expectedErrReason:   testErrReason,
 			expectedRemediation: testRemediation,
@@ -55,7 +56,7 @@ func TestNewVerifierResult(t *testing.T) {
 		{
 			name:                "error with detail",
 			message:             testMsg1,
-			err:                 errors.ErrorCodeUnknown.WithError(fmt.Errorf(testErrReason)).WithRemediation(testRemediation).WithDetail(testMsg2),
+			err:                 errors.ErrorCodeUnknown.WithError(e.New(testErrReason)).WithRemediation(testRemediation).WithDetail(testMsg2),
 			expectedMsg:         testMsg2,
 			expectedErrReason:   testErrReason,
 			expectedRemediation: testRemediation,

--- a/pkg/verifier/types/types_test.go
+++ b/pkg/verifier/types/types_test.go
@@ -16,8 +16,9 @@ limitations under the License.
 package types
 
 import (
-	"fmt"
 	"testing"
+
+	e "errors"
 
 	"github.com/ratify-project/ratify/errors"
 )
@@ -47,7 +48,7 @@ func TestCreateVerifierResult(t *testing.T) {
 		{
 			name:                "error without detail",
 			message:             testMsg1,
-			err:                 errors.ErrorCodeUnknown.WithError(fmt.Errorf(testErrReason)).WithRemediation(testRemediation),
+			err:                 errors.ErrorCodeUnknown.WithError(e.New(testErrReason)).WithRemediation(testRemediation),
 			expectedMsg:         testMsg1,
 			expectedErrReason:   testErrReason,
 			expectedRemediation: testRemediation,
@@ -55,7 +56,7 @@ func TestCreateVerifierResult(t *testing.T) {
 		{
 			name:                "error with detail",
 			message:             testMsg1,
-			err:                 errors.ErrorCodeUnknown.WithError(fmt.Errorf(testErrReason)).WithRemediation(testRemediation).WithDetail(testMsg2),
+			err:                 errors.ErrorCodeUnknown.WithError(e.New(testErrReason)).WithRemediation(testRemediation).WithDetail(testMsg2),
 			expectedMsg:         testMsg2,
 			expectedErrReason:   testErrReason,
 			expectedRemediation: testRemediation,


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
There are a bunch of PRs blocking due to unknown golang-ci-lint issue. I tried to bump up the golangci-lint version to unblock it, which works on my forked repo.

This PR bumps up the golangci-lint version and addresses the new linter warnings. I just wonder if we should just pin the version to latest instead.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
