### PR TITLE
chore: add notation-trust-policy e2e test

### DIFF
--- a/charts/ratify/templates/verifier.yaml
+++ b/charts/ratify/templates/verifier.yaml
@@ -101,10 +101,11 @@ spec:
             {{- end }}
           {{- end}}
           trustedIdentities:
-            {{- range $j, $store := $policy.trustedIdentities }}
-            {{- if eq $store "*" }}
+            {{- $trustedIdentities := $policy.trustedIdentities | default (list "*") }}
+            {{- range $j, $identity := $trustedIdentities }}
+            {{- if eq $identity "*" }}
             - "*"
-            {{- else }} 
+            {{- else }}
             - "x509.subject: {{ . }}"
             {{- end }}
             {{- end }}

--- a/test/bats/base-test.bats
+++ b/test/bats/base-test.bats
@@ -84,7 +84,6 @@ RATIFY_NAMESPACE=gatekeeper-system
         --set notation.trustPolicies[0].trustStores[1]=tsa:notationCerts[1] \
         --set notation.trustPolicies[0].trustStores[2]=signingAuthority:notationCerts[2] \
         --set notation.trustPolicies[1].registryScopes[0]="registry2.azurecr.io/" \
-        --set notation.trustPolicies[1].trustedIdentities[0]="cert identity 2" \
         --set notation.trustPolicies[1].trustStores[0]=ca:notationCerts[1])
 
     # the expected partial output
@@ -125,7 +124,7 @@ spec:
             - ca:cert-0
             - tsa:cert-1
             - signingAuthority:cert-2
-          trustedIdentities: 
+          trustedIdentities:
             - "x509.subject: cert identity 1"
         - name: trustPolicy-1  
           registryScopes:
@@ -134,8 +133,8 @@ spec:
             level: strict  
           trustStores:
             - ca:cert-3
-          trustedIdentities: 
-            - "x509.subject: cert identity 2"
+          trustedIdentities:
+            - "*"
 EOF
     )
 


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
This PR adds an e2e test to ensure that the helm chart template for verifier-notation is rendered properly when custom attributes for notation's trust policies is provided by the user.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Adds e2e test for #1965 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?
This is an update to the e2e bats file. If the PR succeeds the checks, it means that the test passes.

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
