### PR TITLE
chore: update workflows according to the latest supported k8s version

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        KUBERNETES_VERSION: ["1.30.6"]
+        KUBERNETES_VERSION: ["1.31.2"]
         GATEKEEPER_VERSION: ["3.18.0"]
     uses: ./.github/workflows/e2e-k8s.yml
     with:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        KUBERNETES_VERSION: ["1.29.10", "1.30.6"]
+        KUBERNETES_VERSION: ["1.30.6", "1.31.2"]
         GATEKEEPER_VERSION: ["3.16.0", "3.17.0", "3.18.0"]
     uses: ./.github/workflows/e2e-k8s.yml
     with:
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        KUBERNETES_VERSION: ["1.29.10", "1.30.6"]
+        KUBERNETES_VERSION: ["1.30.6", "1.31.2"] 
         GATEKEEPER_VERSION: ["3.16.0", "3.17.0", "3.18.0"]
     uses: ./.github/workflows/e2e-aks.yml
     with:

--- a/.github/workflows/e2e-aks.yml
+++ b/.github/workflows/e2e-aks.yml
@@ -9,7 +9,7 @@ on:
       k8s_version:
         description: "Kubernetes version"
         required: true
-        default: "1.30.6"
+        default: "1.31.2"
         type: string
       gatekeeper_version:
         description: "Gatekeeper version"

--- a/.github/workflows/e2e-k8s.yml
+++ b/.github/workflows/e2e-k8s.yml
@@ -9,7 +9,7 @@ on:
       k8s_version:
         description: "Kubernetes version"
         required: true
-        default: "1.30.6"
+        default: "1.31.2"
         type: string
       gatekeeper_version:
         description: "Gatekeeper version"

--- a/.github/workflows/run-full-validation.yml
+++ b/.github/workflows/run-full-validation.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        KUBERNETES_VERSION: ["1.29.10", "1.30.6"]
+        KUBERNETES_VERSION: ["1.30.6", "1.31.2"]
         GATEKEEPER_VERSION: ["3.16.0", "3.17.0", "3.18.0"]
     uses: ./.github/workflows/e2e-k8s.yml
     with:
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        KUBERNETES_VERSION: ["1.29.10", "1.30.6"]
+        KUBERNETES_VERSION: ["1.30.6", "1.31.2"]
         GATEKEEPER_VERSION: ["3.16.0", "3.17.0", "3.18.0"]
     uses: ./.github/workflows/e2e-aks.yml
     with:


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
We need to bump up the Kubernetes versions in the Kubernetes test matrix to 1.30 and 1.31 respectively since v1.29 is no longer maintained by Kubernetes community.

## Which issue(s) this PR fixes:
Fixes #1992 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
