### PR TITLE
feat: add v2 server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright The Ratify Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.24-alpine@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN go build -o /app/out/ /app/cmd/ratify-gatekeeper-provider
+
+FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
+
+WORKDIR /app
+
+COPY --from=builder /app/out/ratify-gatekeeper-provider ./
+
+EXPOSE 6001
+
+USER 65532:65532
+
+ENTRYPOINT ["/app/ratify-gatekeeper-provider"]

--- a/cmd/ratify-gatekeeper-provider/main.go
+++ b/cmd/ratify-gatekeeper-provider/main.go
@@ -1,0 +1,68 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"time"
+
+	"github.com/ratify-project/ratify/v2/internal/httpserver"
+	"github.com/sirupsen/logrus"
+)
+
+// main is the entry point for the Ratify server.
+func main() {
+	if err := startRatify(parse()); err != nil {
+		logrus.Errorf("Failed to start Ratify: %v", err)
+		panic(err)
+	}
+}
+
+type options struct {
+	configFilePath    string
+	httpServerAddress string
+	certFile          string
+	keyFile           string
+	verifyTimeout     time.Duration
+}
+
+func parse() *options {
+	opts := &options{}
+	flag.StringVar(&opts.configFilePath, "config", "", "Path to the Ratify configuration file")
+	flag.StringVar(&opts.httpServerAddress, "address", "", "HTTP server address")
+	flag.StringVar(&opts.certFile, "cert-file", "", "Path to the TLS certificate file")
+	flag.StringVar(&opts.keyFile, "key-file", "", "Path to the TLS key file")
+	flag.DurationVar(&opts.verifyTimeout, "verify-timeout", 5*time.Second, "Verification timeout duration (e.g. 5s, 1m), default is 5 seconds")
+
+	flag.Parse()
+	logrus.Infof("Starting Ratify with options: %+v", opts)
+	return opts
+}
+
+func startRatify(opts *options) error {
+	if len(opts.httpServerAddress) == 0 {
+		return errors.New("HTTP server address is required")
+	}
+	serverOpts := &httpserver.ServerOptions{
+		HTTPServerAddress: opts.httpServerAddress,
+		CertFile:          opts.certFile,
+		KeyFile:           opts.keyFile,
+		VerifyTimeout:     opts.verifyTimeout,
+	}
+	httpserver.StartServer(serverOpts, opts.configFilePath)
+	return nil
+}

--- a/cmd/ratify-gatekeeper-provider/main.go
+++ b/cmd/ratify-gatekeeper-provider/main.go
@@ -63,6 +63,5 @@ func startRatify(opts *options) error {
 		KeyFile:           opts.keyFile,
 		VerifyTimeout:     opts.verifyTimeout,
 	}
-	httpserver.StartServer(serverOpts, opts.configFilePath)
-	return nil
+	return httpserver.StartServer(serverOpts, opts.configFilePath)
 }

--- a/cmd/ratify-gatekeeper-provider/main_test.go
+++ b/cmd/ratify-gatekeeper-provider/main_test.go
@@ -117,6 +117,15 @@ func TestStartRatify(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "failed to start the server",
+			opts: &options{
+				httpServerAddress: ":8080",
+				configFilePath:    "config.yaml",
+				certFile:          "cert.pem",
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/ratify-gatekeeper-provider/main_test.go
+++ b/cmd/ratify-gatekeeper-provider/main_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMain(t *testing.T) {
+	args := []string{
+		"-config=config.json",
+		"-cert-file=cert.pem",
+		"-key-file=key.pem",
+		"-verify-timeout=10s",
+	}
+	oldArgs := os.Args
+	defer func() {
+		os.Args = oldArgs
+	}()
+	os.Args = append([]string{"cmd"}, args...)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic, but got none")
+		}
+	}()
+	main()
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected *options
+	}{
+		{
+			name: "all options set",
+			args: []string{
+				"-config=config.json",
+				"-address=:8080",
+				"-cert-file=cert.pem",
+				"-key-file=key.pem",
+				"-verify-timeout=10s",
+			},
+			expected: &options{
+				configFilePath:    "config.json",
+				httpServerAddress: ":8080",
+				certFile:          "cert.pem",
+				keyFile:           "key.pem",
+				verifyTimeout:     10 * time.Second,
+			},
+		},
+		{
+			name: "only timeout provided",
+			args: []string{
+				"-verify-timeout=30s",
+			},
+			expected: &options{
+				verifyTimeout: 30 * time.Second,
+			},
+		},
+		{
+			name: "default values",
+			args: []string{},
+			expected: &options{
+				verifyTimeout: 5 * time.Second,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and reset original command-line args and flags
+			oldArgs := os.Args
+			os.Args = append([]string{"cmd"}, tt.args...)
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+			opts := parse()
+			if !reflect.DeepEqual(opts, tt.expected) {
+				t.Errorf("parse() = %+v, want %+v", opts, tt.expected)
+			}
+
+			// Restore original args
+			os.Args = oldArgs
+		})
+	}
+}
+func TestStartRatify(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        *options
+		expectError bool
+	}{
+		{
+			name: "missing http server address",
+			opts: &options{
+				configFilePath: "config.yaml",
+				verifyTimeout:  5 * time.Second,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := startRatify(tt.opts)
+			if (err != nil) != tt.expectError {
+				t.Errorf("startRatify() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}

--- a/configs/config.json
+++ b/configs/config.json
@@ -4,27 +4,14 @@
             "name": "notation-1",
             "type": "notation",
             "parameters": {
-                "trustPolicyDocument": {
-                    "Version": "1.0",
-                    "trustPolicies": [
-                        {
-                            "name": "default",
-                            "registryScopes": [
-                                "*"
-                            ],
-                            "signatureVerification": {
-                                "level": "strict"
-                            },
-                            "trustStores": [
-                                "ca:ratify"
-                            ],
-                            "trustedIdentities": [
-                                "*"
-                            ]
-                        }
-                    ]
-                },
-                "trustStorePath": "/app/notation"
+                "certificates": [
+                    {
+                        "files": [
+                            "/path/to/your/cert.crt",
+                            "/path/to/your/certDirectory"
+                        ]
+                    }
+                ]
             }
         }
     ],

--- a/configs/config.json
+++ b/configs/config.json
@@ -1,0 +1,54 @@
+{
+    "verifiers": [
+        {
+            "name": "notation-1",
+            "type": "notation",
+            "parameters": {
+                "trustPolicyDocument": {
+                    "Version": "1.0",
+                    "trustPolicies": [
+                        {
+                            "name": "default",
+                            "registryScopes": [
+                                "*"
+                            ],
+                            "signatureVerification": {
+                                "level": "strict"
+                            },
+                            "trustStores": [
+                                "ca:ratify"
+                            ],
+                            "trustedIdentities": [
+                                "*"
+                            ]
+                        }
+                    ]
+                },
+                "trustStorePath": "/app/notation"
+            }
+        }
+    ],
+    "stores": {
+        "docker.io": {
+            "type": "registry-store",
+            "parameters": {
+                "credential": {
+                    "username": "",
+                    "password": ""
+                }
+            }
+        }
+    },
+    "policyEnforcer": {
+        "type": "threshold-policy",
+        "parameters": {
+            "policy": {
+                "rules": [
+                    {
+                        "verifierName": "notation-1"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,8 @@ require (
 	github.com/owenrumney/go-sarif/v2 v2.3.3
 	github.com/pkg/errors v0.9.1
 	github.com/ratify-project/ratify v1.4.0
+	github.com/ratify-project/ratify-go v0.0.0-20250409071324-ecbad89bc5e1
+	github.com/ratify-project/ratify-verifier-go/notation v0.0.0-20250411030115-011378ff3b1c
 	github.com/sigstore/cosign/v2 v2.2.4
 	github.com/sigstore/sigstore v1.9.4
 	github.com/sirupsen/logrus v1.9.3

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"github.com/ratify-project/ratify-go"
+	"github.com/ratify-project/ratify/v2/internal/policyenforcer"
+	policyFactory "github.com/ratify-project/ratify/v2/internal/policyenforcer/factory"
+	"github.com/ratify-project/ratify/v2/internal/store"
+	"github.com/ratify-project/ratify/v2/internal/verifier"
+	"github.com/ratify-project/ratify/v2/internal/verifier/factory"
+)
+
+// Options contains the configuration options to create a new executor.
+type Options struct {
+	// Verifiers contains the configuration options for the verifiers. Required.
+	Verifiers []factory.NewVerifierOptions `json:"verifiers"`
+
+	// Stores contains the configuration options for the stores. Required.
+	Stores store.PatternOptions `json:"stores"`
+
+	// Policy contains the configuration options for the policy enforcer.
+	// Optional.
+	Policy *policyFactory.NewPolicyEnforcerOptions `json:"policyEnforcer,omitempty"`
+}
+
+// NewExecutor creates a new [ratify.Executor] instance based on the provided
+// options.
+func NewExecutor(opts *Options) (*ratify.Executor, error) {
+	verifiers, err := verifier.NewVerifiers(opts.Verifiers)
+	if err != nil {
+		return nil, err
+	}
+
+	storeMux, err := store.NewStore(opts.Stores)
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := policyenforcer.NewPolicyEnforcer(opts.Policy)
+	if err != nil {
+		return nil, err
+	}
+
+	return ratify.NewExecutor(storeMux, verifiers, policy)
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -16,6 +16,8 @@ limitations under the License.
 package executor
 
 import (
+	"fmt"
+
 	"github.com/ratify-project/ratify-go"
 	"github.com/ratify-project/ratify/v2/internal/policyenforcer"
 	policyFactory "github.com/ratify-project/ratify/v2/internal/policyenforcer/factory"
@@ -40,6 +42,9 @@ type Options struct {
 // NewExecutor creates a new [ratify.Executor] instance based on the provided
 // options.
 func NewExecutor(opts *Options) (*ratify.Executor, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("executor options cannot be nil")
+	}
 	verifiers, err := verifier.NewVerifiers(opts.Verifiers)
 	if err != nil {
 		return nil, err

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ratify-project/ratify-go"
+	"github.com/ratify-project/ratify/v2/internal/store/factory"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	ef "github.com/ratify-project/ratify/v2/internal/policyenforcer/factory"
+	vf "github.com/ratify-project/ratify/v2/internal/verifier/factory"
+)
+
+const (
+	mockVerifierName       = "mock-verifier-name"
+	mockVerifierType       = "mock-verifier-type"
+	mockStoreType          = "mock-store"
+	mockPolicyEnforcerType = "mock-policy-enforcer"
+)
+
+type mockStore struct{}
+
+func (m *mockStore) Resolve(_ context.Context, _ string) (ocispec.Descriptor, error) {
+	return ocispec.Descriptor{}, nil
+}
+
+func (m *mockStore) ListReferrers(_ context.Context, _ string, _ []string, _ func(referrers []ocispec.Descriptor) error) error {
+	return nil
+}
+
+func (m *mockStore) FetchBlob(_ context.Context, _ string, _ ocispec.Descriptor) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockStore) FetchManifest(_ context.Context, _ string, _ ocispec.Descriptor) ([]byte, error) {
+	return nil, nil
+}
+
+func newMockStore(_ factory.NewStoreOptions) (ratify.Store, error) {
+	return &mockStore{}, nil
+}
+
+type mockPolicyEnforcer struct{}
+
+func (m *mockPolicyEnforcer) Evaluator(_ context.Context, _ string) (ratify.Evaluator, error) {
+	return nil, nil
+}
+
+func createPolicyEnforcer(_ *ef.NewPolicyEnforcerOptions) (ratify.PolicyEnforcer, error) {
+	return &mockPolicyEnforcer{}, nil
+}
+
+type mockVerifier struct{}
+
+func (m *mockVerifier) Name() string {
+	return mockVerifierName
+}
+func (m *mockVerifier) Type() string {
+	return mockVerifierType
+}
+func (m *mockVerifier) Verifiable(_ ocispec.Descriptor) bool {
+	return true
+}
+
+func (m *mockVerifier) Verify(_ context.Context, _ *ratify.VerifyOptions) (*ratify.VerificationResult, error) {
+	return &ratify.VerificationResult{}, nil
+}
+
+func createMockVerifier(_ vf.NewVerifierOptions) (ratify.Verifier, error) {
+	return &mockVerifier{}, nil
+}
+
+func TestNewExecutor(t *testing.T) {
+	factory.RegisterStoreFactory(mockStoreType, newMockStore)
+	vf.RegisterVerifierFactory(mockVerifierType, createMockVerifier)
+	ef.RegisterPolicyEnforcerFactory(mockPolicyEnforcerType, createPolicyEnforcer)
+
+	tests := []struct {
+		name           string
+		opts           *Options
+		expectErr      bool
+		expectExecutor bool
+	}{
+		{
+			name:           "failed to create verifiers",
+			opts:           &Options{},
+			expectErr:      true,
+			expectExecutor: false,
+		},
+		{
+			name: "failed to create store",
+			opts: &Options{
+				Verifiers: []vf.NewVerifierOptions{
+					{
+						Name: mockVerifierName,
+						Type: mockVerifierType,
+					},
+				},
+			},
+			expectErr:      true,
+			expectExecutor: false,
+		},
+		{
+			name: "failed to create policy enforcer",
+			opts: &Options{
+				Verifiers: []vf.NewVerifierOptions{
+					{
+						Name: mockVerifierName,
+						Type: mockVerifierType,
+					},
+				},
+				Stores: map[string]factory.NewStoreOptions{
+					"test": {
+						Type: mockStoreType,
+					},
+				},
+				Policy: &ef.NewPolicyEnforcerOptions{},
+			},
+			expectErr:      true,
+			expectExecutor: false,
+		},
+		{
+			name: "valid options",
+			opts: &Options{
+				Verifiers: []vf.NewVerifierOptions{
+					{
+						Name: mockVerifierName,
+						Type: mockVerifierType,
+					},
+				},
+				Stores: map[string]factory.NewStoreOptions{
+					"test": {
+						Type: mockStoreType,
+					},
+				},
+				Policy: &ef.NewPolicyEnforcerOptions{
+					Type: mockPolicyEnforcerType,
+				},
+			},
+			expectErr:      false,
+			expectExecutor: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			executor, err := NewExecutor(test.opts)
+			if (err != nil) != test.expectErr {
+				t.Errorf("expected error: %v, got: %v", test.expectErr, err)
+			}
+			if (executor != nil) != test.expectExecutor {
+				t.Errorf("expected executor: %v, got: %v", test.expectExecutor, executor != nil)
+			}
+		})
+	}
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -98,6 +98,12 @@ func TestNewExecutor(t *testing.T) {
 		expectExecutor bool
 	}{
 		{
+			name:           "nil options",
+			opts:           nil,
+			expectErr:      true,
+			expectExecutor: false,
+		},
+		{
 			name:           "failed to create verifiers",
 			opts:           &Options{},
 			expectErr:      true,

--- a/internal/httpserver/config/config.go
+++ b/internal/httpserver/config/config.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/ratify-project/ratify/v2/internal/executor"
+)
+
+const (
+	configFileName = "config.json"
+	configFileDir  = ".ratify"
+)
+
+var (
+	initConfigDir         = new(sync.Once)
+	configDir             string
+	defaultConfigFilePath string
+	homeDir               string
+)
+
+// Load reads the configuration file from the specified path and unmarshals it
+// into an executor.Options struct.
+func Load(configPath string) (*executor.Options, error) {
+	body, err := os.ReadFile(getConfigurationFile(configPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read configuration file: %w", err)
+	}
+
+	config := &executor.Options{}
+	if err = json.Unmarshal(body, config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal configuration: %w", err)
+	}
+
+	return config, nil
+}
+
+func getConfigurationFile(configFilePath string) string {
+	if configFilePath == "" {
+		if configDir == "" {
+			initConfigDir.Do(initDefaultPaths)
+		}
+		return defaultConfigFilePath
+	}
+	return configFilePath
+}
+
+func initDefaultPaths() {
+	if configDir != "" {
+		return
+	}
+	configDir = os.Getenv("RATIFY_CONFIG")
+	if configDir == "" {
+		configDir = filepath.Join(getHomeDir(), configFileDir)
+	}
+	defaultConfigFilePath = filepath.Join(configDir, configFileName)
+}
+
+func getHomeDir() string {
+	if homeDir == "" {
+		homeDir = get()
+	}
+	return homeDir
+}

--- a/internal/httpserver/config/config_test.go
+++ b/internal/httpserver/config/config_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/ratify-project/ratify/v2/internal/executor"
+	"github.com/ratify-project/ratify/v2/internal/store"
+	"github.com/ratify-project/ratify/v2/internal/verifier/factory"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoad(t *testing.T) {
+	tempDir := t.TempDir()
+	validConfig := `{"verifiers":[],"stores":{}}`
+
+	validConfigPath := filepath.Join(tempDir, "valid_config.json")
+	err := os.WriteFile(validConfigPath, []byte(validConfig), 0600)
+	assert.NoError(t, err)
+
+	t.Run("valid config file", func(t *testing.T) {
+		config, err := Load(validConfigPath)
+		assert.NoError(t, err)
+		assert.Equal(t, &executor.Options{
+			Verifiers: []factory.NewVerifierOptions{},
+			Stores:    store.PatternOptions{},
+		}, config)
+	})
+
+	t.Run("non-existent config file", func(t *testing.T) {
+		_, err := Load(filepath.Join(tempDir, "nonexistent.json"))
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid json format", func(t *testing.T) {
+		invalidConfigPath := filepath.Join(tempDir, "invalid_config.json")
+		err := os.WriteFile(invalidConfigPath, []byte(`{"Field1": "value1", "Field2":}`), 0600)
+		assert.NoError(t, err)
+
+		_, err = Load(invalidConfigPath)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty config path uses default", func(t *testing.T) {
+		initConfigDir = new(sync.Once)
+		configDir = tempDir
+		defaultConfigFilePath = filepath.Join(configDir, configFileName)
+		err := os.WriteFile(defaultConfigFilePath, []byte(validConfig), 0600)
+		assert.NoError(t, err)
+
+		config, err := Load("")
+		assert.NoError(t, err)
+		assert.Equal(t, &executor.Options{
+			Verifiers: []factory.NewVerifierOptions{},
+			Stores:    store.PatternOptions{},
+		}, config)
+	})
+
+	t.Run("empty config path and no default", func(t *testing.T) {
+		initConfigDir = new(sync.Once)
+		configDir = ""
+		defaultConfigFilePath = filepath.Join(configDir, configFileName)
+
+		config, err := Load("")
+		assert.Error(t, err)
+		assert.Nil(t, config)
+	})
+}

--- a/internal/httpserver/config/homedir_unix.go
+++ b/internal/httpserver/config/homedir_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"os/user"
+)
+
+func get() string {
+	home := os.Getenv("HOME")
+	if home == "" {
+		if u, err := user.Current(); err == nil {
+			return u.HomeDir
+		}
+	}
+	return home
+}

--- a/internal/httpserver/config/homedir_unix_test.go
+++ b/internal/httpserver/config/homedir_unix_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"os/user"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	originalHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", originalHome)
+
+	t.Run("HOME environment variable set", func(t *testing.T) {
+		expectedHome := "/tmp/testhome"
+		os.Setenv("HOME", expectedHome)
+		if home := get(); home != expectedHome {
+			t.Errorf("expected home %q, got %q", expectedHome, home)
+		}
+	})
+
+	t.Run("HOME environment variable unset, fallback to user.Current()", func(t *testing.T) {
+		os.Unsetenv("HOME")
+		currentUser, err := user.Current()
+		if err != nil {
+			t.Fatalf("failed to get current user: %v", err)
+		}
+		if home := get(); home != currentUser.HomeDir {
+			t.Errorf("expected home %q, got %q", currentUser.HomeDir, home)
+		}
+	})
+}

--- a/internal/httpserver/config/homedir_windows.go
+++ b/internal/httpserver/config/homedir_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "os"
+
+func get() string {
+	return os.Getenv("USERPROFILE")
+}

--- a/internal/httpserver/config/homedir_windows_test.go
+++ b/internal/httpserver/config/homedir_windows_test.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	originalUserProfile := os.Getenv("USERPROFILE")
+	defer os.Setenv("USERPROFILE", originalUserProfile)
+
+	testCases := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "USERPROFILE set to valid path",
+			envValue: "C:\\Users\\TestUser",
+			expected: "C:\\Users\\TestUser",
+		},
+		{
+			name:     "USERPROFILE set to empty string",
+			envValue: "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv("USERPROFILE", tc.envValue)
+			result := get()
+			if result != tc.expected {
+				t.Errorf("get() = %q; want %q", result, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/httpserver/response.go
+++ b/internal/httpserver/response.go
@@ -1,0 +1,112 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"encoding/json"
+
+	"github.com/ratify-project/ratify-go"
+	"github.com/sirupsen/logrus"
+)
+
+// verificationResult is a rendered view of [ratify.VerificationResult].
+type verificationResult struct {
+	VerifierName string `json:"verifierName"`
+	Description  string `json:"description,omitempty"`
+	Detail       string `json:"detail,omitempty"`
+	ErrorReason  string `json:"errorReason,omitempty"`
+}
+
+// validationReport is a rendered view of [ratify.ValidationReport].
+type validationReport struct {
+	Subject         string                `json:"subject"`
+	Artifact        string                `json:"artifact"`
+	Results         []*verificationResult `json:"results,omitempty"`
+	ArtifactReports []*validationReport   `json:"artifactReports,omitempty"`
+}
+
+// result is a rendered view of [ratify.ValidationResult].
+type result struct {
+	Succeeded       bool                `json:"succeeded"`
+	ArtifactReports []*validationReport `json:"artifactReports"`
+}
+
+func convertResult(src *ratify.ValidationResult) *result {
+	if src == nil {
+		return nil
+	}
+	result := &result{
+		Succeeded:       src.Succeeded,
+		ArtifactReports: convertValidationReports(src.ArtifactReports),
+	}
+
+	return result
+}
+
+func convertValidationReports(src []*ratify.ValidationReport) []*validationReport {
+	if src == nil {
+		return nil
+	}
+	reports := make([]*validationReport, len(src))
+	for idx, report := range src {
+		reports[idx] = convertValidationReport(report)
+	}
+	return reports
+}
+
+func convertValidationReport(src *ratify.ValidationReport) *validationReport {
+	if src == nil {
+		return nil
+	}
+	report := &validationReport{
+		Subject:         src.Subject,
+		Artifact:        src.Artifact.Digest.String(),
+		ArtifactReports: convertValidationReports(src.ArtifactReports),
+	}
+
+	if len(src.Results) > 0 {
+		report.Results = make([]*verificationResult, len(src.Results))
+		for idx, result := range src.Results {
+			report.Results[idx] = convertVerificationResult(result)
+		}
+	}
+
+	return report
+}
+
+func convertVerificationResult(src *ratify.VerificationResult) *verificationResult {
+	if src == nil {
+		return nil
+	}
+	result := &verificationResult{
+		Description: src.Description,
+	}
+	if src.Verifier != nil {
+		result.VerifierName = src.Verifier.Name()
+	}
+	if src.Err != nil {
+		result.ErrorReason = src.Err.Error()
+	}
+	if src.Detail != nil {
+		detail, err := json.Marshal(src.Detail)
+		if err != nil {
+			logrus.Errorf("failed to marshal detail: %v", err)
+			return nil
+		}
+		result.Detail = string(detail)
+	}
+	return result
+}

--- a/internal/httpserver/response_test.go
+++ b/internal/httpserver/response_test.go
@@ -27,19 +27,19 @@ import (
 )
 
 const (
-	subject1 = "subject1"
-	subject2 = "subject2"
-	mockName = "mock-name"
-	mockType = "mock-type"
+	subject1         = "subject1"
+	subject2         = "subject2"
+	mockVerifierName = "mock-verifier-name"
+	mockVerifierType = "mock-verifier-type"
 )
 
 type mockVerifier struct{}
 
 func (m *mockVerifier) Name() string {
-	return mockName
+	return mockVerifierName
 }
 func (m *mockVerifier) Type() string {
-	return mockType
+	return mockVerifierType
 }
 func (m *mockVerifier) Verifiable(_ ocispec.Descriptor) bool {
 	return true
@@ -55,20 +55,20 @@ func TestConvertResult(t *testing.T) {
 		src      *ratify.ValidationResult
 		expected *result
 	}{
-		// {
-		// 	name:     "nil source",
-		// 	src:      nil,
-		// 	expected: nil,
-		// },
-		// {
-		// 	name: "nil ArtifactReports",
-		// 	src: &ratify.ValidationResult{
-		// 		ArtifactReports: nil,
-		// 	},
-		// 	expected: &result{
-		// 		ArtifactReports: nil,
-		// 	},
-		// },
+		{
+			name:     "nil source",
+			src:      nil,
+			expected: nil,
+		},
+		{
+			name: "nil ArtifactReports",
+			src: &ratify.ValidationResult{
+				ArtifactReports: nil,
+			},
+			expected: &result{
+				ArtifactReports: nil,
+			},
+		},
 		{
 			name: "nonempty ArtifactReports",
 			src: &ratify.ValidationResult{
@@ -95,10 +95,41 @@ func TestConvertResult(t *testing.T) {
 						Results: []*verificationResult{
 							nil,
 							{
-								VerifierName: mockName,
+								VerifierName: mockVerifierName,
 								ErrorReason:  "error",
 								Detail:       "{}",
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nonempty ArtifactReports with invalid detail",
+			src: &ratify.ValidationResult{
+				ArtifactReports: []*ratify.ValidationReport{
+					nil,
+					{
+						Subject: subject1,
+						Results: []*ratify.VerificationResult{
+							nil,
+							{
+								Verifier: &mockVerifier{},
+								Err:      errors.New("error"),
+								Detail:   make(chan int),
+							},
+						},
+					},
+				},
+			},
+			expected: &result{
+				ArtifactReports: []*validationReport{
+					nil,
+					{
+						Subject: subject1,
+						Results: []*verificationResult{
+							nil,
+							nil,
 						},
 					},
 				},

--- a/internal/httpserver/response_test.go
+++ b/internal/httpserver/response_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/ratify-project/ratify-go"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	subject1 = "subject1"
+	subject2 = "subject2"
+	mockName = "mock-name"
+	mockType = "mock-type"
+)
+
+type mockVerifier struct{}
+
+func (m *mockVerifier) Name() string {
+	return mockName
+}
+func (m *mockVerifier) Type() string {
+	return mockType
+}
+func (m *mockVerifier) Verifiable(_ ocispec.Descriptor) bool {
+	return true
+}
+
+func (m *mockVerifier) Verify(_ context.Context, _ *ratify.VerifyOptions) (*ratify.VerificationResult, error) {
+	return &ratify.VerificationResult{}, nil
+}
+
+func TestConvertResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      *ratify.ValidationResult
+		expected *result
+	}{
+		// {
+		// 	name:     "nil source",
+		// 	src:      nil,
+		// 	expected: nil,
+		// },
+		// {
+		// 	name: "nil ArtifactReports",
+		// 	src: &ratify.ValidationResult{
+		// 		ArtifactReports: nil,
+		// 	},
+		// 	expected: &result{
+		// 		ArtifactReports: nil,
+		// 	},
+		// },
+		{
+			name: "nonempty ArtifactReports",
+			src: &ratify.ValidationResult{
+				ArtifactReports: []*ratify.ValidationReport{
+					nil,
+					{
+						Subject: subject1,
+						Results: []*ratify.VerificationResult{
+							nil,
+							{
+								Verifier: &mockVerifier{},
+								Err:      errors.New("error"),
+								Detail:   map[string]any{},
+							},
+						},
+					},
+				},
+			},
+			expected: &result{
+				ArtifactReports: []*validationReport{
+					nil,
+					{
+						Subject: subject1,
+						Results: []*verificationResult{
+							nil,
+							{
+								VerifierName: mockName,
+								ErrorReason:  "error",
+								Detail:       "{}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := convertResult(test.src)
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("Expected result: %v, got: %v", test.expected, result)
+			}
+		})
+	}
+}

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -1,0 +1,267 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
+	"github.com/ratify-project/ratify-go"
+	"github.com/ratify-project/ratify/v2/internal/executor"
+	"github.com/ratify-project/ratify/v2/internal/httpserver/config"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	serverRootURL        = "/ratify/gatekeeper/v2"
+	verifyPath           = "verify"
+	defaultVerifyTimeout = 5 * time.Second
+	readTimeout          = 5 * time.Second
+	writeTimeout         = 5 * time.Second
+	idleTimeout          = 60 * time.Second
+)
+
+var tlsCert atomic.Value
+
+type server struct {
+	address              string
+	certFile             string
+	keyFile              string
+	router               *mux.Router
+	executor             *ratify.Executor
+	verifyRequestTimeout time.Duration
+}
+
+// ServerOptions holds the configuration options for the Ratify server.
+type ServerOptions struct {
+	// HTTPServerAddress is the address where the server will listen for
+	// incoming requests.
+	// It should be in the format "host:port" (e.g., ":8080").
+	// Required.
+	HTTPServerAddress string
+
+	// CertFile is the path to the TLS certificate file. If not provided, the
+	// server will run without TLS.
+	// Optional.
+	CertFile string
+
+	// KeyFile is the path to the TLS key file. If not provided, the server
+	// will run without TLS.
+	// Optional.
+	KeyFile string
+
+	// VerifyTimeout is the duration to wait for a verification request to
+	// complete before timing out. Default is 5 seconds if not specified.
+	// Optional.
+	VerifyTimeout time.Duration
+}
+
+// StartServer initializes and starts the Ratify server with provided options
+// and configuration file path.
+func StartServer(opts *ServerOptions, configPath string) {
+	executorOpts, err := config.Load(configPath)
+	if err != nil {
+		logrus.Errorf("Failed to load executor options: %v", err)
+		os.Exit(1)
+	}
+
+	server, err := newServer(opts, executorOpts)
+	if err != nil {
+		logrus.Errorf("Failed to create server: %v", err)
+		os.Exit(1)
+	}
+
+	logrus.Infof("Starting server at port: %s", opts.HTTPServerAddress)
+	if err := server.Run(); err != nil {
+		logrus.Errorf("Failed to start server: %v", err)
+		os.Exit(1)
+	}
+}
+
+func newServer(serverOpts *ServerOptions, executorOpts *executor.Options) (*server, error) {
+	e, err := executor.NewExecutor(executorOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create executor: %w", err)
+	}
+	server := &server{
+		router:               mux.NewRouter(),
+		address:              serverOpts.HTTPServerAddress,
+		certFile:             serverOpts.CertFile,
+		keyFile:              serverOpts.KeyFile,
+		verifyRequestTimeout: serverOpts.VerifyTimeout,
+		executor:             e,
+	}
+	if server.verifyRequestTimeout == 0 {
+		server.verifyRequestTimeout = defaultVerifyTimeout
+	}
+	if err := server.registerHandlers(); err != nil {
+		return nil, fmt.Errorf("failed to register handlers: %w", err)
+	}
+	return server, nil
+}
+
+func (s *server) registerHandlers() error {
+	if err := s.registerVerifyHandler(); err != nil {
+		return err
+	}
+	if err := s.registerMutateHandler(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// TODO: implement mutate handler.
+func (s *server) registerMutateHandler() error {
+	return nil
+}
+
+func (s *server) registerVerifyHandler() error {
+	verifyURL, err := url.JoinPath(serverRootURL, verifyPath)
+	if err != nil {
+		return err
+	}
+	s.router.Methods(http.MethodPost).Path(verifyURL).Handler(middlewareWithTimeout(s.verifyHandler(), s.verifyRequestTimeout))
+	return nil
+}
+
+func (s *server) verifyHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = s.verify(r.Context(), w, r)
+	}
+}
+
+// verify handles the verification request from Gatekeeper.
+func (s *server) verify(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	var providerRequest externaldata.ProviderRequest
+	if err = json.Unmarshal(body, &providerRequest); err != nil {
+		return fmt.Errorf("failed to unmarshal request body to provider request: %w", err)
+	}
+
+	results := make([]externaldata.Item, len(providerRequest.Request.Keys))
+	for idx, key := range providerRequest.Request.Keys {
+		item := externaldata.Item{
+			Key: key,
+		}
+		opts := ratify.ValidateArtifactOptions{
+			Subject: key,
+		}
+		result, err := s.executor.ValidateArtifact(ctx, opts)
+		if err != nil {
+			item.Error = err.Error()
+		}
+		item.Value = convertResult(result)
+		results[idx] = item
+	}
+
+	response := externaldata.ProviderResponse{
+		APIVersion: "externaldata.gatekeeper.sh/v1beta1",
+		Kind:       "ProviderResponse",
+		Response: externaldata.Response{
+			Items: results,
+		},
+	}
+	w.WriteHeader(http.StatusOK)
+	return json.NewEncoder(w).Encode(response)
+}
+
+func middlewareWithTimeout(next http.Handler, timeout time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// Run starts the HTTP server and listens for incoming requests.
+// It also handles graceful shutdown on receiving an interrupt signal.
+func (s *server) Run() error {
+	srv := &http.Server{
+		Addr:         s.address,
+		Handler:      s.router,
+		WriteTimeout: writeTimeout,
+		ReadTimeout:  readTimeout,
+		IdleTimeout:  idleTimeout,
+	}
+	go func() {
+		if s.certFile != "" && s.keyFile != "" {
+			logrus.Infof("starting server with TLS at %s", s.address)
+			if err := loadCertificate(s.certFile, s.keyFile); err != nil {
+				logrus.Errorf("failed to load certificate: %v", err)
+				return
+			}
+			// Use GetCertificate to dynamically load certificates.
+			srv.TLSConfig = &tls.Config{
+				MinVersion:     tls.VersionTLS13,
+				GetCertificate: getCertificate,
+			}
+			if err := srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+				logrus.Errorf("failed to start server: %v", err)
+			}
+		} else {
+			logrus.Infof("starting server without TLS at %s", s.address)
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logrus.Errorf("failed to start server: %v", err)
+			}
+		}
+	}()
+
+	// Handle graceful shutdown.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	<-quit
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.verifyRequestTimeout)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		logrus.Errorf("failed to shutdown server: %v", err)
+		return err
+	}
+	return nil
+}
+
+func loadCertificate(certFile, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return fmt.Errorf("failed to load certificate: %w", err)
+	}
+	tlsCert.Store(&cert)
+	return nil
+}
+
+func getCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if cert := tlsCert.Load(); cert != nil {
+		return cert.(*tls.Certificate), nil
+	}
+	return nil, nil
+}

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -83,24 +83,21 @@ type ServerOptions struct {
 
 // StartServer initializes and starts the Ratify server with provided options
 // and configuration file path.
-func StartServer(opts *ServerOptions, configPath string) {
+func StartServer(opts *ServerOptions, configPath string) error {
 	executorOpts, err := config.Load(configPath)
 	if err != nil {
 		logrus.Errorf("Failed to load executor options: %v", err)
-		os.Exit(1)
+		return err
 	}
 
 	server, err := newServer(opts, executorOpts)
 	if err != nil {
 		logrus.Errorf("Failed to create server: %v", err)
-		os.Exit(1)
+		return err
 	}
 
 	logrus.Infof("Starting server at port: %s", opts.HTTPServerAddress)
-	if err := server.Run(); err != nil {
-		logrus.Errorf("Failed to start server: %v", err)
-		os.Exit(1)
-	}
+	return server.Run()
 }
 
 func newServer(serverOpts *ServerOptions, executorOpts *executor.Options) (*server, error) {

--- a/internal/httpserver/server_test.go
+++ b/internal/httpserver/server_test.go
@@ -1,0 +1,390 @@
+/*
+Copyright The Ratify Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/ratify-project/ratify-go"
+	"github.com/ratify-project/ratify/v2/internal/executor"
+	"github.com/ratify-project/ratify/v2/internal/store"
+	storeFactory "github.com/ratify-project/ratify/v2/internal/store/factory"
+	"github.com/ratify-project/ratify/v2/internal/verifier/factory"
+)
+
+const (
+	invalidConfigPath = "/invalid/path"
+	registryPattern   = "registry.pattern"
+	mockStoreType     = "mock-store-type"
+	artifact1         = "test.registry.io/test/image1:v1"
+)
+
+func createMockVerifier(factory.NewVerifierOptions) (ratify.Verifier, error) {
+	return &mockVerifier{}, nil
+}
+
+type mockStore struct{}
+
+func (m *mockStore) Resolve(_ context.Context, _ string) (ocispec.Descriptor, error) {
+	return ocispec.Descriptor{}, nil
+}
+
+func (m *mockStore) ListReferrers(_ context.Context, _ string, _ []string, _ func(referrers []ocispec.Descriptor) error) error {
+	return nil
+}
+
+func (m *mockStore) FetchBlob(_ context.Context, _ string, _ ocispec.Descriptor) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockStore) FetchManifest(_ context.Context, _ string, _ ocispec.Descriptor) ([]byte, error) {
+	return nil, nil
+}
+
+func newMockStore(_ storeFactory.NewStoreOptions) (ratify.Store, error) {
+	return &mockStore{}, nil
+}
+
+func TestStartServer(t *testing.T) {
+	tempDir := t.TempDir()
+	factory.RegisterVerifierFactory(mockVerifierType, createMockVerifier)
+	storeFactory.RegisterStoreFactory(mockStoreType, newMockStore)
+
+	tests := []struct {
+		name          string
+		serverOpts    *ServerOptions
+		executorOpts  *executor.Options
+		configPath    string
+		expectedError bool
+	}{
+		{
+			name:          "Invalid config path",
+			serverOpts:    &ServerOptions{},
+			executorOpts:  &executor.Options{},
+			configPath:    invalidConfigPath,
+			expectedError: true,
+		},
+		{
+			name:          "Failed to create the executor",
+			serverOpts:    &ServerOptions{},
+			executorOpts:  &executor.Options{},
+			configPath:    filepath.Join(tempDir, "config.json"),
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.configPath != invalidConfigPath {
+				raw, err := json.Marshal(test.executorOpts)
+				if err != nil {
+					t.Fatalf("failed to marshal executor options: %v", err)
+				}
+				if err := os.WriteFile(test.configPath, raw, 0600); err != nil {
+					t.Fatalf("failed to write config file: %v", err)
+				}
+			}
+
+			err := StartServer(test.serverOpts, test.configPath)
+			if (err != nil) != test.expectedError {
+				t.Errorf("expected error: %v, got: %v", test.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestStartServer_NoTLS(t *testing.T) {
+	tempDir := t.TempDir()
+
+	executorOpts := &executor.Options{
+		Verifiers: []factory.NewVerifierOptions{
+			{
+				Name: mockVerifierName,
+				Type: mockVerifierType,
+			},
+		},
+		Stores: store.PatternOptions{
+			registryPattern: storeFactory.NewStoreOptions{
+				Type: mockStoreType,
+			},
+		},
+	}
+
+	raw, err := json.Marshal(executorOpts)
+	if err != nil {
+		t.Fatalf("failed to marshal executor options: %v", err)
+	}
+	configPath := filepath.Join(tempDir, "config.json")
+	if err := os.WriteFile(configPath, raw, 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	serverOpts := &ServerOptions{
+		HTTPServerAddress: ":8080",
+	}
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- StartServer(serverOpts, configPath)
+	}()
+
+	time.Sleep(1 * time.Second)
+	p, _ := os.FindProcess(os.Getpid())
+	if err = p.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("failed to send SIGTERM: %v", err)
+	}
+
+	if err := <-errChan; err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+}
+
+func TestStartServer_TLSEnabled(t *testing.T) {
+	tempDir := t.TempDir()
+
+	executorOpts := &executor.Options{
+		Verifiers: []factory.NewVerifierOptions{
+			{
+				Name: mockVerifierName,
+				Type: mockVerifierType,
+			},
+		},
+		Stores: store.PatternOptions{
+			registryPattern: storeFactory.NewStoreOptions{
+				Type: mockStoreType,
+			},
+		},
+	}
+
+	raw, err := json.Marshal(executorOpts)
+	if err != nil {
+		t.Fatalf("failed to marshal executor options: %v", err)
+	}
+	configPath := filepath.Join(tempDir, "config.json")
+	if err := os.WriteFile(configPath, raw, 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	certPath, keyPath, err := createTLSCertAndKey(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create TLS cert and key: %v", err)
+	}
+	serverOpts := &ServerOptions{
+		HTTPServerAddress: ":8080",
+		CertFile:          certPath,
+		KeyFile:           keyPath,
+	}
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- StartServer(serverOpts, configPath)
+	}()
+
+	time.Sleep(1 * time.Second)
+	p, _ := os.FindProcess(os.Getpid())
+	if err = p.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("failed to send SIGTERM: %v", err)
+	}
+
+	if err := <-errChan; err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+}
+
+func TestStartServer_InvalidTLS(t *testing.T) {
+	tempDir := t.TempDir()
+
+	executorOpts := &executor.Options{
+		Verifiers: []factory.NewVerifierOptions{
+			{
+				Name: mockVerifierName,
+				Type: mockVerifierType,
+			},
+		},
+		Stores: store.PatternOptions{
+			registryPattern: storeFactory.NewStoreOptions{
+				Type: mockStoreType,
+			},
+		},
+	}
+
+	raw, err := json.Marshal(executorOpts)
+	if err != nil {
+		t.Fatalf("failed to marshal executor options: %v", err)
+	}
+	configPath := filepath.Join(tempDir, "config.json")
+	if err := os.WriteFile(configPath, raw, 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	serverOpts := &ServerOptions{
+		HTTPServerAddress: ":8080",
+		CertFile:          "invalid/path/to/cert.pem",
+		KeyFile:           "invalid/path/to/key.pem",
+	}
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- StartServer(serverOpts, configPath)
+	}()
+
+	time.Sleep(1 * time.Second)
+	p, _ := os.FindProcess(os.Getpid())
+	if err = p.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("failed to send SIGTERM: %v", err)
+	}
+
+	if err := <-errChan; err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+}
+
+func createTLSCertAndKey(dir string) (string, string, error) {
+	// 1. Generate a private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(fmt.Errorf("failed to generate private key: %w", err))
+	}
+
+	// 2. Create a certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject: pkix.Name{
+			CommonName:   "localhost",
+			Organization: []string{"Example Org"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(1 * time.Hour), // valid for 1 year
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	// 3. Self-sign the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		panic(fmt.Errorf("failed to create certificate: %w", err))
+	}
+
+	// 4. Encode and save the certificate to cert.pem
+	certPath := filepath.Join(dir, "cert.pem")
+	certOut, err := os.Create(certPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to open cert.pem for writing: %w", err)
+	}
+	defer certOut.Close()
+
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return "", "", fmt.Errorf("failed to write data to cert.pem: %w", err)
+	}
+
+	// 5. Encode and save the private key to key.pem
+	keyPath := filepath.Join(dir, "key.pem")
+	keyOut, err := os.Create(keyPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to open key.pem for writing: %w", err)
+	}
+	defer keyOut.Close()
+
+	privateKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	if err := pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes}); err != nil {
+		return "", "", fmt.Errorf("failed to write data to key.pem: %w", err)
+	}
+
+	return certPath, keyPath, nil
+}
+func TestVerify(t *testing.T) {
+	executor := ratify.Executor{}
+	server := &server{
+		executor: &executor,
+	}
+
+	tests := []struct {
+		name          string
+		requestBody   string
+		expectedError bool
+		expectedItems []externaldata.Item
+	}{
+		{
+			name: "Valid request",
+			requestBody: `{
+				"request": {
+					"keys": ["artifact1"]
+				}
+			}`,
+			expectedError: false,
+			expectedItems: []externaldata.Item{
+				{
+					Key:   "artifact1",
+					Value: nil,
+					Error: "store must be configured",
+				},
+			},
+		},
+		{
+			name:          "Invalid JSON",
+			requestBody:   `{invalid-json}`,
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/verify", strings.NewReader(test.requestBody))
+			w := httptest.NewRecorder()
+
+			err := server.verify(context.Background(), w, req)
+			if (err != nil) != test.expectedError {
+				t.Errorf("expected error: %v, got: %v", test.expectedError, err)
+			}
+
+			if !test.expectedError {
+				var response externaldata.ProviderResponse
+				if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+
+				if !reflect.DeepEqual(response.Response.Items, test.expectedItems) {
+					t.Errorf("expected items: %v, got: %v", test.expectedItems, response.Response.Items)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
This PR created V2 ratify server integrating the new `ratify-go` and `ratify-verifier-go` libraries. And the new server could be started by a standalone binary instead of through `ratify serve` command.

### Overview of new files
`cmd/ratify-gatekeeper-provider`: it's the entrypoint of the new server which will parses options and starts the server.
`internal/httpserver`: it's the main server implementation which will initialize the server with executor, verifier, store and policy enforcer. And it starts the http/https server after registering the `verify` handler.
`Dockerfile`: the Dockerfile to build the v2 Ratify server binary

`internal/executor`: it creates an executor with verifiers, stores and policy enforcer.
`internal/store`, `internal/verifier`, `internal/store`: use factory pattern to register required plugins.

For registry store, this PR only adds the basic authentication which requires users to provide username/password or refreshToken.
For notation verifier, this PR supports file-system based trust store which requires mounting the trust store while starting the server in pods.

### Test
`Test Request`:
```
curl -X POST "http://localhost:6001/ratify/gatekeeper/v2/verify" \
     -H "Content-Type: application/json" \
     -d '{
           "apiVersion": "v1",
           "kind": "ProviderRequest",
           "request": {
              "keys": ["libinbinacr.azurecr.io/tsa:v1"]
           }
         }`
```

`Success Response`:
```json
{
  "apiVersion": "externaldata.gatekeeper.sh/v1alpha1",
  "kind": "ProviderResponse",
  "response": {
    "items": [
      {
        "key": "libinbinacr.azurecr.io/tsa:v1",
        "value": {
          "succeeded": true,
          "artifactReports": [
            {
              "subject": "libinbinacr.azurecr.io/tsa@sha256:b29a73887df6dbe143b651d55fd3d95827234f628dbac29851f53003299d2b93",
              "artifact": "sha256:0f308a6876a6a633467c1f3ecc4fe20b6ae7cdb6c07d6069f26bedab83488925",
              "results": [
                {
                  "verifierName": "notation-1",
                  "description": "Notation signature verification succeeded",
                  "detail": "{\"Issuer\":\"CN=ratify4,O=Notary,L=Seattle,ST=WA,C=US\",\"SN\":\"CN=ratify4,O=Notary,L=Seattle,ST=WA,C=US\"}"
                }
              ]
            }
          ]
        }
      }
    ]
  }
}
```
`Failure response`:
```json
{
  "apiVersion": "externaldata.gatekeeper.sh/v1beta1",
  "kind": "ProviderResponse",
  "response": {
    "items": [
      {
        "key": "libinbinacr.azurecr.io/tsa:v1",
        "value": {
          "succeeded": false,
          "artifactReports": [
            {
              "subject": "libinbinacr.azurecr.io/tsa@sha256:b29a73887df6dbe143b651d55fd3d95827234f628dbac29851f53003299d2b93",
              "artifact": "sha256:0f308a6876a6a633467c1f3ecc4fe20b6ae7cdb6c07d6069f26bedab83488925",
              "results": [
                {
                  "verifierName": "notation-1",
                  "errorReason": "verification time is after certificate \"CN=ratify4,O=Notary,L=Seattle,ST=WA,C=US\" validity period, it was expired at \"Wed, 09 Apr 2025 12:07:14 +0000\""
                }
              ]
            },
            {
              "subject": "libinbinacr.azurecr.io/tsa@sha256:b29a73887df6dbe143b651d55fd3d95827234f628dbac29851f53003299d2b93",
              "artifact": "sha256:00df52d1e42a3bff0f8cefa45fe24d98a547ddc908dbb5d54100fa7b9c9ffa27",
              "results": [
                {
                  "verifierName": "notation-1",
                  "errorReason": "signature is not produced by a trusted signer"
                }
              ]
            }
          ]
        }
      }
    ]
  }
}
```

Adding unit tests.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/ratify-project/ratify/issues/2192

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
