### PR TITLE
ci: remove labeled pull_request_target

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,8 +1,6 @@
 name: build-pr
 
 on:
-  pull_request_target:
-    types: [labeled]
   pull_request:
     branches:
       - v1-dev

--- a/.github/workflows/high-availability.yml
+++ b/.github/workflows/high-availability.yml
@@ -1,8 +1,6 @@
 name: high-availability
 
 on:
-  pull_request_target:
-    types: [labeled]
   pull_request:
     branches:
       - v1-dev

--- a/.github/workflows/quick-start.yml
+++ b/.github/workflows/quick-start.yml
@@ -4,8 +4,6 @@ permissions:
   contents: read
 
 on:
-  pull_request_target:
-    types: [labeled]
   pull_request:
     branches:
       - v1-dev


### PR DESCRIPTION
# Description

## What this PR does / why we need it:
Remove labeled pull_request_target as it will always triggered CI jobs on labeled PRs.

## Which issue(s) this PR fixes *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Helm Chart Change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

# Post Merge Requirements
- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
